### PR TITLE
Add Spartan Kids page and navigation links

### DIFF
--- a/404.html
+++ b/404.html
@@ -87,6 +87,9 @@
               <li>
                 <a href="./grapPage.html">Grappling & Submission</a>
               </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
             </ul>
           </li>
           <li><a href="./team.html">Instructor</a></li>
@@ -161,6 +164,9 @@
                     <li>
                       <a href="./grapPage.html">Grappling & Submission</a>
                     </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
                   </ul>
                 </li>
                 <li><a href="./team.html">Instructor</a></li>
@@ -658,6 +664,7 @@
                   <a href="./jjbPage.html">Brazilian Jiujitsu</a>
                 </li>
                 <li><a href="./grapPage.html">Grappling </a></li>
+                <li><a href="./kidsPage.html">Spartan Kids</a></li>
                 <li><a href="./team.html">Instructor</a></li>
                 <!--<li><a href="./about-us.html">Centros</a></li>-->
                 <li><a href="./services.html">Técnicas</a></li>

--- a/class-timetable.html
+++ b/class-timetable.html
@@ -70,6 +70,9 @@ td{padding-top:5px !important;padding-bottom:5px !important;}}
               <li>
                 <a href="./grapPage.html">Grappling & Submission</a>
               </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
             </ul>
           </li>
           <li><a href="./team.html">Instructor</a></li>
@@ -149,6 +152,9 @@ td{padding-top:5px !important;padding-bottom:5px !important;}}
                     <li>
                       <a href="./grapPage.html">Grappling & Submission</a>
                     </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
                   </ul>
                 </li>
                 <li><a href="./team.html">Instructor</a></li>
@@ -544,6 +550,7 @@ td{padding-top:5px !important;padding-bottom:5px !important;}}
                   <a href="./jjbPage.html">Brazilian Jiujitsu</a>
                 </li>
                 <li><a href="./grapPage.html">Grappling </a></li>
+                <li><a href="./kidsPage.html">Spartan Kids</a></li>
                 <li><a href="./team.html">Instructor</a></li>
                 <!--<li><a href="./about-us.html">Centros</a></li>-->
                 <li><a href="./services.html">Técnicas</a></li>

--- a/contact.html
+++ b/contact.html
@@ -65,6 +65,9 @@
               <li>
                 <a href="./grapPage.html">Grappling & Submission</a>
               </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
             </ul>
           </li>
           <li><a href="./team.html">Instructor</a></li>
@@ -144,6 +147,9 @@
                     <li>
                       <a href="./grapPage.html">Grappling & Submission</a>
                     </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
                   </ul>
                 </li>
                 <li><a href="./team.html">Instructor</a></li>
@@ -319,6 +325,7 @@
                   <a href="./jjbPage.html">Brazilian Jiujitsu</a>
                 </li>
                 <li><a href="./grapPage.html">Grappling </a></li>
+                <li><a href="./kidsPage.html">Spartan Kids</a></li>
                 <li><a href="./team.html">Instructor</a></li>
                 <!--<li><a href="./about-us.html">Centros</a></li>-->
                 <li><a href="./services.html">Técnicas</a></li>

--- a/gallery.html
+++ b/gallery.html
@@ -67,6 +67,9 @@
               <li>
                 <a href="./grapPage.html">Grappling & Submission</a>
               </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
             </ul>
           </li>
           <li><a href="./team.html">Instructor</a></li>
@@ -146,6 +149,9 @@
                     <li>
                       <a href="./grapPage.html">Grappling & Submission</a>
                     </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
                   </ul>
                 </li>
                 <li><a href="./team.html">Instructor</a></li>
@@ -1048,6 +1054,7 @@
                   <a href="./jjbPage.html">Brazilian Jiujitsu</a>
                 </li>
                 <li><a href="./grapPage.html">Grappling </a></li>
+                <li><a href="./kidsPage.html">Spartan Kids</a></li>
                 <li><a href="./team.html">Instructor</a></li>
                 <!--<li><a href="./about-us.html">Centros</a></li>-->
                 <li><a href="./services.html">Técnicas</a></li>

--- a/grapPage.html
+++ b/grapPage.html
@@ -68,6 +68,9 @@
               <li>
                 <a href="./grapPage.html">Grappling & Submission</a>
               </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
             </ul>
           </li>
           <li><a href="./team.html">Instructor</a></li>
@@ -147,6 +150,9 @@
                     <li>
                       <a href="./grapPage.html">Grappling & Submission</a>
                     </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
                   </ul>
                 </li>
                 <li><a href="./team.html">Instructor</a></li>
@@ -535,6 +541,7 @@ hacerlo con un método y en un ambiente personalizados.
                   <a href="./jjbPage.html">Brazilian Jiujitsu</a>
                 </li>
                 <li><a href="./grapPage.html">Grappling </a></li>
+                <li><a href="./kidsPage.html">Spartan Kids</a></li>
                 <li><a href="./team.html">Instructor</a></li>
                 <!--<li><a href="./about-us.html">Centros</a></li>-->
                 <li><a href="./services.html">Técnicas</a></li>

--- a/index.html
+++ b/index.html
@@ -67,6 +67,9 @@
               <li>
                 <a href="./grapPage.html">Grappling & Submission</a>
               </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
             </ul>
           </li>
           <li><a href="./team.html">Instructor</a></li>
@@ -146,6 +149,9 @@
                     <li>
                       <a href="./grapPage.html">Grappling & Submission</a>
                     </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
                   </ul>
                 </li>
                 <li><a href="./team.html">Instructor</a></li>
@@ -386,6 +392,20 @@
                 <span>Sparta MMA</span>
                 <h5>Grappling & Submission</h5>
                 <a href="./grapPage.html"><i class="fa fa-angle-right"></i></a>
+              </div>
+            </div>
+          </div>
+          <div class="col-lg-4 col-md-6">
+            <div class="class-item">
+              <div class="ci-pic">
+                <a href="./kidsPage.html"
+                  ><img src="img/disciplinas/mats.jpg" load="lazy" alt=""
+                /></a>
+              </div>
+              <div class="ci-text">
+                <span>Sparta MMA</span>
+                <h5>Spartan Kids</h5>
+                <a href="./kidsPage.html"><i class="fa fa-angle-right"></i></a>
               </div>
             </div>
           </div>
@@ -674,6 +694,7 @@
                   <a href="./jjbPage.html">Brazilian Jiujitsu</a>
                 </li>
                 <li><a href="./grapPage.html">Grappling </a></li>
+                <li><a href="./kidsPage.html">Spartan Kids</a></li>
                 <li><a href="./team.html">Instructor</a></li>
                 <!--<li><a href="./about-us.html">Centros</a></li>-->
                 <li><a href="./services.html">Técnicas</a></li>

--- a/jjbPage.html
+++ b/jjbPage.html
@@ -68,6 +68,9 @@
               <li>
                 <a href="./grapPage.html">Grappling & Submission</a>
               </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
             </ul>
           </li>
           <li><a href="./team.html">Instructor</a></li>
@@ -148,6 +151,9 @@
                     <li>
                       <a href="./grapPage.html">Grappling & Submission</a>
                     </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
                   </ul>
                 </li>
                 <li><a href="./team.html">Instructor</a></li>
@@ -653,6 +659,7 @@ Aquí, cada clase es un paso hacia la superación personal, en un ambiente segur
                   <a href="./jjbPage.html">Brazilian Jiujitsu</a>
                 </li>
                 <li><a href="./grapPage.html">Grappling </a></li>
+                <li><a href="./kidsPage.html">Spartan Kids</a></li>
                 <li><a href="./team.html">Instructor</a></li>
                 <!--<li><a href="./about-us.html">Centros</a></li>-->
                 <li><a href="./services.html">Técnicas</a></li>

--- a/kidsPage.html
+++ b/kidsPage.html
@@ -1,0 +1,302 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="description" content="Clases de artes marciales para niños en Sparta MMA." />
+    <meta name="keywords" content="Spartan Kids, niños, artes marciales, mma, jiujitsu, toledo" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <link rel="icon" href="./img/soloCasco.png" />
+    <title>Spartan Kids - Sparta MMA</title>
+
+    <!-- Google Font -->
+    <link href="https://fonts.googleapis.com/css?family=Muli:300,400,500,600,700,800,900&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css?family=Oswald:300,400,500,600,700&display=swap" rel="stylesheet" />
+
+    <!-- Css Styles -->
+    <link rel="stylesheet" href="css/bootstrap.min.css" type="text/css" />
+    <link rel="stylesheet" href="css/font-awesome.min.css" type="text/css" />
+    <link rel="stylesheet" href="css/flaticon.css" type="text/css" />
+    <link rel="stylesheet" href="css/owl.carousel.min.css" type="text/css" />
+    <link rel="stylesheet" href="css/barfiller.css" type="text/css" />
+    <link rel="stylesheet" href="css/magnific-popup.css" type="text/css" />
+    <link rel="stylesheet" href="css/slicknav.min.css" type="text/css" />
+    <link rel="stylesheet" href="css/style.css" type="text/css" />
+    <link rel="stylesheet" href="css/style2.css" type="text/css" />
+  </head>
+
+  <body>
+    <!-- Page Preloder -->
+    <div id="preloder">
+      <div class="loader"></div>
+    </div>
+
+    <!-- Offcanvas Menu Section Begin -->
+    <div class="offcanvas-menu-overlay"></div>
+    <div class="offcanvas-menu-wrapper">
+      <div class="canvas-close">
+        <i class="fa fa-close"></i>
+      </div>
+      <nav class="canvas-menu mobile-menu">
+        <ul>
+          <li class="active"><a href="./index.html">Inicio</a></li>
+          <li>
+            <a href="#">Disciplinas</a>
+            <ul class="dropdown">
+              <li>
+                <a href="./mmaPage.html">MMA - Artes Marciales Mixtas</a>
+              </li>
+              <li>
+                <a href="./jjbPage.html">BJJ - Brazilian Jiujitsu</a>
+              </li>
+              <li>
+                <a href="./grapPage.html">Grappling & Submission</a>
+              </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
+            </ul>
+          </li>
+          <li><a href="./team.html">Instructor</a></li>
+          <li><a href="./prices.html">Tarifas</a></li>
+          <li><a href="./class-timetable.html">Horario</a></li>
+          <li><a href="./gallery.html">Galería</a></li>
+          <li><a href="./store.html">Tienda</a></li>
+          <li><a href="./contact.html">Contacto</a></li>
+        </ul>
+      </nav>
+      <div id="mobile-menu-wrap"></div>
+      <div class="canvas-social">
+        <a href="tel:+34628689601"><i class="fa fa-phone fa-sm"></i></a>
+        <a href="https://api.whatsapp.com/send?phone=34628689601"><i class="fa fa-whatsapp"></i></a>
+        <a href="https://www.instagram.com/sparta.m.m.a/?hl=es"><i class="fa fa-instagram"></i></a>
+        <a href="mailto:spartahellfighters@gmail.com"><i class="fa fa-envelope-o"></i></a>
+      </div>
+    </div>
+    <!-- Offcanvas Menu Section End -->
+
+    <!-- Header Section Begin -->
+    <header class="header-section">
+      <div class="container-fluid">
+        <div class="row">
+          <div class="col-lg-3">
+            <div class="logo">
+              <a>
+                <img src="img/fullLogoWhite1.png" id="spartaName" load="lazy" class="disciplinaSpartaLogo" />
+              </a>
+              <a>
+                <img src="img/spartanMMAWhitePNG.png" id="spartaNameMobile" load="lazy" class="disciplinaSpartaLogo" />
+              </a>
+            </div>
+          </div>
+          <div class="col-lg-6">
+            <nav class="nav-menu">
+              <ul>
+                <li class="active"><a href="./index.html">Inicio</a></li>
+                <li>
+                  <a href="#">Disciplinas</a>
+                  <ul class="dropdown">
+                    <li><a href="./mmaPage.html">MMA - Artes Marciales Mixtas</a></li>
+                    <li><a href="./jjbPage.html">BJJ - Brazilian Jiujitsu</a></li>
+                    <li><a href="./grapPage.html">Grappling & Submission</a></li>
+                    <li><a href="./kidsPage.html">Spartan Kids</a></li>
+                  </ul>
+                </li>
+                <li><a href="./team.html">Instructor</a></li>
+                <li><a href="./prices.html">Tarifas</a></li>
+                <li><a href="./class-timetable.html">Horario</a></li>
+                <li><a href="./gallery.html">Galería</a></li>
+                <li><a href="./store.html">Tienda</a></li>
+                <li><a href="./contact.html">Contacto</a></li>
+              </ul>
+            </nav>
+          </div>
+          <div class="col-lg-3">
+            <div class="top-option">
+              <div class="to-social">
+                <a href="tel:+34628689601"><i class="fa fa-phone fa-sm"></i></a>
+                <a href="https://api.whatsapp.com/send?phone=34628689601"><i class="fa fa-whatsapp"></i></a>
+                <a href="https://www.instagram.com/sparta.m.m.a/?hl=es"><i class="fa fa-instagram"></i></a>
+                <a href="mailto:spartahellfighters@gmail.com"><i class="fa fa-envelope-o"></i></a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="canvas-open">
+          <i class="fa fa-bars"></i>
+        </div>
+      </div>
+    </header>
+    <!-- Header End -->
+
+    <!-- Hero Section Begin -->
+    <section class="blog-details-hero set-bg" data-setbg="./img/disciplinas/mats.jpg">
+      <a href="#kidsText">
+        <div class="container">
+          <div class="row">
+            <div class="col-lg-8 p-0 m-auto">
+              <div class="bh-text">
+                <h1 style="color: #e41c1f; font-weight: bolder">Spartan Kids</h1>
+                <h3>Clases para niños</h3>
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </section>
+    <!-- Hero Section End -->
+
+    <!-- Details Section Begin -->
+    <section class="blog-details-section spad">
+      <div class="container">
+        <div class="row">
+          <div class="col-lg-8 p-0 m-auto">
+            <div class="blog-details-text">
+              <div id="kidsText" class="blog-details-title">
+                <h5>Spartan Kids</h5>
+                <p><b>¡Diversión, disciplina y deporte para los más pequeños!</b></p>
+                <p>
+                  Nuestro programa Spartan Kids introduce a los niños en las artes
+                  marciales de una manera segura y entretenida. A través de juegos
+                  y ejercicios, desarrollan coordinación, respeto y confianza en
+                  sí mismos mientras aprenden técnicas básicas.
+                </p>
+                <p>
+                  Las clases están diseñadas para todas las edades y niveles. Los
+                  entrenadores de Sparta MMA guían a cada alumno para que mejore
+                  su forma física y aprenda valores esenciales como la
+                  perseverancia y el trabajo en equipo.
+                </p>
+              </div>
+              <div class="blog-details-pic">
+                <div class="blog-details-pic-item">
+                  <img src="img/disciplinas/mats.jpg" alt="" />
+                </div>
+                <div class="blog-details-pic-item">
+                  <img src="img/disciplinas/grap2.jpg" alt="" />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <!-- Details Section End -->
+
+    <!-- Private Classes Section Begin -->
+    <section class="choseus-section spad clasesPrivadas">
+      <div class="explanation">
+        <h2>Clases privadas Spartan Kids</h2>
+        <div class="texto">
+          Sesiones individuales de 45 minutos para que los más pequeños
+          disfruten de una atención personalizada. ¡Consulta tarifas y
+          disponibilidad!
+        </div>
+        <h3>Las clases privadas son ideales si...</h3>
+        <ul>
+          <li>Tu hijo quiere iniciarse en las artes marciales de forma segura.</li>
+          <li>Busca mejorar rápidamente con la ayuda de un instructor dedicado.</li>
+          <li>Necesita preparar competiciones o reforzar habilidades específicas.</li>
+        </ul>
+        <br /><br />
+      </div>
+      <div class="container">
+        <div class="cta-form">
+          <h3>Reserva ya tu clase privada</h3>
+          <p>Escuela de Artes Marciales en Toledo - Sparta MMA</p>
+        </div>
+        <form action="https://api.web3forms.com/submit" method="POST">
+          <input type="hidden" name="access_key" value="d1ba759c-c0d9-42e0-853e-7d3645a10102" />
+          <input type="hidden" name="subject" value="Nueva Reserva de Clase Privada Spartan Kids" />
+          <input type="text" placeholder="Name" class="form__input" name="nombre" id="name" />
+          <input type="hidden" name="from_name" value="Notificación" />
+          <input type="hidden" name="redirect" value="https://www.spartamma.es/" />
+          <label for="name" class="form__label">Nombre</label>
+          <input type="email" placeholder="Email" class="form__input" id="email" name="email" />
+          <label for="email" class="form__label">Correo</label>
+          <input type="number" placeholder="Subject" class="form__input" id="subject" name="teléfono" />
+          <label for="subject" class="form__label">Teléfono</label>
+          <button type="submit">Reservar</button>
+        </form>
+      </div>
+    </section>
+    <!-- Private Classes Section End -->
+
+    <!-- Footer Section Begin -->
+    <section class="footer-section">
+      <div class="container">
+        <div class="row">
+          <div class="col-lg-4">
+            <div class="fs-about">
+              <div class="fa-logo">
+                <a href="#"><img src="img/spartaWhite.jpeg" load="lazy" alt="" /></a>
+              </div>
+              <p>
+                En nuestra escuela de artes marciales Sparta MMA, promovemos la
+                salud, deporte, respeto, disciplina, y superación personal.
+              </p>
+              <div class="fa-social">
+                <a href="tel:+34628689601"><i class="fa fa-phone fa-sm"></i></a>
+                <a href="https://api.whatsapp.com/send?phone=34628689601"><i class="fa fa-whatsapp"></i></a>
+                <a href="https://www.instagram.com/sparta.m.m.a/?hl=es"><i class="fa fa-instagram"></i></a>
+                <a href="mailto:spartahellfighters@gmail.com"><i class="fa fa-envelope-o"></i></a>
+              </div>
+            </div>
+          </div>
+          <div class="col-lg-2 col-md-3 col-sm-6">
+            <div class="fs-widget">
+              <h4>Links Útiles</h4>
+              <ul>
+                <li class="active"><a href="./index.html">Inicio</a></li>
+                <li><a href="./mmaPage.html">Artes Marciales Mixtas</a></li>
+                <li><a href="./jjbPage.html">Brazilian Jiujitsu</a></li>
+                <li><a href="./grapPage.html">Grappling </a></li>
+                <li><a href="./kidsPage.html">Spartan Kids</a></li>
+                <li><a href="./team.html">Instructor</a></li>
+                <li><a href="./services.html">Técnicas</a></li>
+                <li><a href="./class-timetable.html">Horario</a></li>
+                <li><a href="./gallery.html">Galería</a></li>
+                <li><a href="./store.html">Tienda</a></li>
+              </ul>
+            </div>
+          </div>
+          <div class="col-lg-2 col-md-3 col-sm-6">
+            <div class="fs-widget">
+              <h4>Soporte</h4>
+              <ul>
+                <li><a href="./privacidad.html">Privacidad</a></li>
+                <li><a href="./terminos.html">Términos</a></li>
+                <li><a href="./contact.html">Contacto</a></li>
+              </ul>
+            </div>
+          </div>
+
+          <div class="col-lg-4 col-md-6">
+            <div class="fs-widget">
+              <h4>Logos</h4>
+              <div class="fw-recent">
+                <div class="fr-item">
+                  <a href="#"><img src="img/footer1.jpg" load="lazy" alt="" /></a>
+                </div>
+                <div class="fr-item">
+                  <a href="#"><img src="img/footer2.jpg" load="lazy" alt="" /></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <!-- Footer Section End -->
+
+    <!-- Js Plugins -->
+    <script src="js/jquery-3.3.1.min.js"></script>
+    <script src="js/bootstrap.min.js"></script>
+    <script src="js/jquery.magnific-popup.min.js"></script>
+    <script src="js/masonry.pkgd.min.js"></script>
+    <script src="js/jquery.barfiller.js"></script>
+    <script src="js/jquery.slicknav.js"></script>
+    <script src="js/owl.carousel.min.js"></script>
+    <script src="js/main.js"></script>
+  </body>
+</html>

--- a/mmaMerch.html
+++ b/mmaMerch.html
@@ -65,6 +65,9 @@
               <li>
                 <a href="./grapPage.html">Grappling & Submission</a>
               </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
             </ul>
           </li>
           <li><a href="./team.html">Instructor</a></li>
@@ -143,6 +146,9 @@
                     <li>
                       <a href="./grapPage.html">Grappling & Submission</a>
                     </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
                   </ul>
                 </li>
                 <li><a href="./team.html">Instructor</a></li>
@@ -304,6 +310,7 @@
                   <a href="./jjbPage.html">Brazilian Jiujitsu</a>
                 </li>
                 <li><a href="./grapPage.html">Grappling </a></li>
+                <li><a href="./kidsPage.html">Spartan Kids</a></li>
                 <li><a href="./team.html">Instructor</a></li>
                 <!--<li><a href="./about-us.html">Centros</a></li>-->
                 <li><a href="./services.html">Técnicas</a></li>

--- a/mmaPage.html
+++ b/mmaPage.html
@@ -68,6 +68,9 @@
               <li>
                 <a href="./grapPage.html">Grappling & Submission</a>
               </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
             </ul>
           </li>
           <li><a href="./team.html">Instructor</a></li>
@@ -148,6 +151,9 @@
                     <li>
                       <a href="./grapPage.html">Grappling & Submission</a>
                     </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
                   </ul>
                 </li>
                 <li><a href="./team.html">Instructor</a></li>
@@ -600,6 +606,7 @@
                   <a href="./jjbPage.html">Brazilian Jiujitsu</a>
                 </li>
                 <li><a href="./grapPage.html">Grappling </a></li>
+                <li><a href="./kidsPage.html">Spartan Kids</a></li>
                 <li><a href="./team.html">Instructor</a></li>
                 <!--<li><a href="./about-us.html">Centros</a></li>-->
                 <li><a href="./services.html">Técnicas</a></li>

--- a/prices.html
+++ b/prices.html
@@ -65,6 +65,9 @@
                   <li>
                     <a href="./grapPage.html">Grappling & Submission</a>
                   </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
                 </ul>
               </li>
               <li><a href="./team.html">Instructor</a></li>
@@ -144,6 +147,9 @@
                         <li>
                           <a href="./grapPage.html">Grappling & Submission</a>
                         </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
                       </ul>
                     </li>
                     <li><a href="./team.html">Instructor</a></li>
@@ -341,6 +347,7 @@
                     <a href="./jjbPage.html">Brazilian Jiujitsu</a>
                   </li>
                   <li><a href="./grapPage.html">Grappling </a></li>
+                <li><a href="./kidsPage.html">Spartan Kids</a></li>
                   <li><a href="./team.html">Instructor</a></li>
                   <!--<li><a href="./about-us.html">Centros</a></li>-->
                   <li><a href="./services.html">Técnicas</a></li>

--- a/privacidad.html
+++ b/privacidad.html
@@ -64,6 +64,9 @@
               <li>
                 <a href="./grapPage.html">Grappling & Submission</a>
               </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
             </ul>
           </li>
           <li><a href="./team.html">Instructor</a></li>
@@ -138,6 +141,9 @@
                     <li>
                       <a href="./grapPage.html">Grappling & Submission</a>
                     </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
                   </ul>
                 </li>
                 <li><a href="./team.html">Instructor</a></li>
@@ -407,6 +413,7 @@
                   <a href="./jjbPage.html">Brazilian Jiujitsu</a>
                 </li>
                 <li><a href="./grapPage.html">Grappling </a></li>
+                <li><a href="./kidsPage.html">Spartan Kids</a></li>
                 <li><a href="./team.html">Instructor</a></li>
                 <!--<li><a href="./about-us.html">Centros</a></li>-->
                 <li><a href="./services.html">Técnicas</a></li>

--- a/services.html
+++ b/services.html
@@ -65,6 +65,9 @@
               <li>
                 <a href="./grapPage.html">Grappling & Submission</a>
               </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
             </ul>
           </li>
           <li><a href="./team.html">Instructor</a></li>
@@ -144,6 +147,9 @@
                     <li>
                       <a href="./grapPage.html">Grappling & Submission</a>
                     </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
                   </ul>
                 </li>
                 <li><a href="./team.html">Instructor</a></li>
@@ -469,6 +475,7 @@
                   <a href="./jjbPage.html">Brazilian Jiujitsu</a>
                 </li>
                 <li><a href="./grapPage.html">Grappling </a></li>
+                <li><a href="./kidsPage.html">Spartan Kids</a></li>
                 <li><a href="./team.html">Instructor</a></li>
                 <!--<li><a href="./about-us.html">Centros</a></li>-->
                 <li><a href="./services.html">Técnicas</a></li>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -80,4 +80,10 @@
         <changefreq>always</changefreq>
         <priority>0.5</priority>
     </url>
+    <url>
+        <loc>https://www.spartamma.es/kidsPage.html</loc>
+        <lastmod>2023-07-06</lastmod>
+        <changefreq>always</changefreq>
+        <priority>0.5</priority>
+    </url>
 </urlset>

--- a/store copy.html
+++ b/store copy.html
@@ -65,6 +65,9 @@
               <li>
                 <a href="./grapPage.html">Grappling & Submission</a>
               </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
             </ul>
           </li>
           <li><a href="./team.html">Instructor</a></li>
@@ -143,6 +146,9 @@
                     <li>
                       <a href="./grapPage.html">Grappling & Submission</a>
                     </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
                   </ul>
                 </li>
                 <li><a href="./team.html">Instructor</a></li>
@@ -343,6 +349,7 @@
                   <a href="./jjbPage.html">Brazilian Jiujitsu</a>
                 </li>
                 <li><a href="./grapPage.html">Grappling </a></li>
+                <li><a href="./kidsPage.html">Spartan Kids</a></li>
                 <li><a href="./team.html">Instructor</a></li>
                 <!--<li><a href="./about-us.html">Centros</a></li>-->
                 <li><a href="./services.html">Técnicas</a></li>

--- a/store.html
+++ b/store.html
@@ -65,6 +65,9 @@
               <li>
                 <a href="./grapPage.html">Grappling & Submission</a>
               </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
             </ul>
           </li>
           <li><a href="./team.html">Instructor</a></li>
@@ -144,6 +147,9 @@
                     <li>
                       <a href="./grapPage.html">Grappling & Submission</a>
                     </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
                   </ul>
                 </li>
                 <li><a href="./team.html">Instructor</a></li>
@@ -421,6 +427,7 @@
                   <a href="./jjbPage.html">Brazilian Jiujitsu</a>
                 </li>
                 <li><a href="./grapPage.html">Grappling </a></li>
+                <li><a href="./kidsPage.html">Spartan Kids</a></li>
                 <li><a href="./team.html">Instructor</a></li>
                 <!--<li><a href="./about-us.html">Centros</a></li>-->
                 <li><a href="./services.html">Técnicas</a></li>

--- a/team.html
+++ b/team.html
@@ -65,6 +65,9 @@
               <li>
                 <a href="./grapPage.html">Grappling & Submission</a>
               </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
             </ul>
           </li>
           <li><a href="./team.html">Instructor</a></li>
@@ -144,6 +147,9 @@
                     <li>
                       <a href="./grapPage.html">Grappling & Submission</a>
                     </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
                   </ul>
                 </li>
                 <li><a href="./team.html">Instructor</a></li>
@@ -736,6 +742,7 @@
                   <a href="./jjbPage.html">Brazilian Jiujitsu</a>
                 </li>
                 <li><a href="./grapPage.html">Grappling </a></li>
+                <li><a href="./kidsPage.html">Spartan Kids</a></li>
                 <li><a href="./team.html">Instructor</a></li>
                 <!--<li><a href="./about-us.html">Centros</a></li>-->
                 <li><a href="./services.html">Técnicas</a></li>

--- a/terminos.html
+++ b/terminos.html
@@ -65,6 +65,9 @@
               <li>
                 <a href="./grapPage.html">Grappling & Submission</a>
               </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
             </ul>
           </li>
           <li><a href="./team.html">Instructor</a></li>
@@ -139,6 +142,9 @@
                     <li>
                       <a href="./grapPage.html">Grappling & Submission</a>
                     </li>
+              <li>
+                <a href="./kidsPage.html">Spartan Kids</a>
+              </li>
                   </ul>
                 </li>
                 <li><a href="./team.html">Instructor</a></li>
@@ -646,6 +652,7 @@
                   <a href="./jjbPage.html">Brazilian Jiujitsu</a>
                 </li>
                 <li><a href="./grapPage.html">Grappling </a></li>
+                <li><a href="./kidsPage.html">Spartan Kids</a></li>
                 <li><a href="./team.html">Instructor</a></li>
                 <!--<li><a href="./about-us.html">Centros</a></li>-->
                 <li><a href="./services.html">Técnicas</a></li>


### PR DESCRIPTION
## Summary
- create dedicated Spartan Kids page with class info and private lesson form
- link Spartan Kids across site navigation, footers, and homepage
- register new page in sitemap

## Testing
- `npm test` (fails: ENOENT package.json)


------
https://chatgpt.com/codex/tasks/task_e_68acafa00dfc832b9c05b8993ae02281