### PR TITLE
Fix mobile menu disciplines dropdown

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -60,8 +60,7 @@
 		Navigation
 	--------------------*/
     $(".mobile-menu").slicknav({
-        prependTo: '#mobile-menu-wrap',
-        allowParentLinks: true
+        prependTo: '#mobile-menu-wrap'
     });
 
     /*------------------


### PR DESCRIPTION
## Summary
- ensure mobile navigation exposes discipline pages by relying on slicknav default parent link behavior

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6de65f34832bbdb4aa3cccfeaf03