### PR TITLE
Add brand partners section and page

### DIFF
--- a/404.html
+++ b/404.html
@@ -671,6 +671,7 @@
                 <li><a href="./class-timetable.html">Horario</a></li>
                 <li><a href="./gallery.html">Galería</a></li>
                 <li><a href="./store.html">Tienda</a></li>
+                <li><a href="./marcas.html">Marcas</a></li>
               </ul>
             </div>
           </div>

--- a/class-timetable.html
+++ b/class-timetable.html
@@ -557,6 +557,7 @@ td{padding-top:5px !important;padding-bottom:5px !important;}}
                 <li><a href="./class-timetable.html">Horario</a></li>
                 <li><a href="./gallery.html">Galería</a></li>
                 <li><a href="./store.html">Tienda</a></li>
+                <li><a href="./marcas.html">Marcas</a></li>
               </ul>
             </div>
           </div>

--- a/gallery.html
+++ b/gallery.html
@@ -1061,6 +1061,7 @@
                 <li><a href="./class-timetable.html">Horario</a></li>
                 <li><a href="./gallery.html">Galería</a></li>
                 <li><a href="./store.html">Tienda</a></li>
+                <li><a href="./marcas.html">Marcas</a></li>
               </ul>
             </div>
           </div>

--- a/grapPage.html
+++ b/grapPage.html
@@ -615,6 +615,7 @@ hacerlo con un método y en un ambiente personalizados.
                 <li><a href="./class-timetable.html">Horario</a></li>
                 <li><a href="./gallery.html">Galería</a></li>
                 <li><a href="./store.html">Tienda</a></li>
+                <li><a href="./marcas.html">Marcas</a></li>
               </ul>
             </div>
           </div>

--- a/index.html
+++ b/index.html
@@ -651,7 +651,35 @@
         </div>
       </div>
     </div>
-    <!-- Get In Touch Section End -->
+    (<!-- Get In Touch Section End -->
+
+    <!-- Brands Section Begin -->
+    <section class="brands-section spad">
+      <div class="container">
+        <div class="row">
+          <div class="col-lg-12 text-center">
+            <div class="section-title">
+              <h2>Marcas con las que trabajamos</h2>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-lg-3 col-md-3 col-sm-6 col-6">
+            <img src="https://via.placeholder.com/300x100?text=MAAT" alt="MAAT" class="img-fluid" />
+          </div>
+          <div class="col-lg-3 col-md-3 col-sm-6 col-6">
+            <img src="https://via.placeholder.com/300x100?text=MAAT+Promo" alt="Sparta MMA usa MAAT" class="img-fluid" />
+          </div>
+          <div class="col-lg-3 col-md-3 col-sm-6 col-6">
+            <img src="https://via.placeholder.com/300x100?text=Patch4Gi" alt="Patch4Gi" class="img-fluid" />
+          </div>
+          <div class="col-lg-3 col-md-3 col-sm-6 col-6">
+            <img src="https://via.placeholder.com/300x100?text=Custom+Fighter" alt="Custom Fighter" class="img-fluid" />
+          </div>
+        </div>
+      </div>
+    </section>
+    <!-- Brands Section End -->
 
     <!-- Footer Section Begin -->
     <section class="footer-section">
@@ -701,6 +729,7 @@
                 <li><a href="./class-timetable.html">Horario</a></li>
                 <li><a href="./gallery.html">Galería</a></li>
                 <li><a href="./store.html">Tienda</a></li>
+                <li><a href="./marcas.html">Marcas</a></li>
               </ul>
             </div>
           </div>

--- a/jjbPage.html
+++ b/jjbPage.html
@@ -717,6 +717,7 @@ Aquí, cada clase es un paso hacia la superación personal, en un ambiente segur
                 <li><a href="./class-timetable.html">Horario</a></li>
                 <li><a href="./gallery.html">Galería</a></li>
                 <li><a href="./store.html">Tienda</a></li>
+                <li><a href="./marcas.html">Marcas</a></li>
               </ul>
             </div>
           </div>

--- a/kidsPage.html
+++ b/kidsPage.html
@@ -300,6 +300,7 @@
                 <li><a href="./class-timetable.html">Horario</a></li>
                 <li><a href="./gallery.html">Galería</a></li>
                 <li><a href="./store.html">Tienda</a></li>
+                <li><a href="./marcas.html">Marcas</a></li>
               </ul>
             </div>
           </div>

--- a/marcas.html
+++ b/marcas.html
@@ -4,16 +4,16 @@
     <meta charset="UTF-8" />
     <meta
       name="description"
-      content="Contacto de la escuela de artes marciales Sparta MMA."
+      content="Marcas con las que trabajamos en Sparta MMA."
     />
     <meta
       name="keywords"
-      content="Contacto, información, gym, mma, jiujitsu, toledo."
+      content="Marcas, patrocinadores, equipamiento, mma, jiujitsu, toledo."
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <link rel="icon" href="./img/soloCasco.png" />
-    <title>Contacto - Sparta MMA</title>
+    <title>Marcas - Sparta MMA</title>
 
     <!-- Google Font -->
     <link
@@ -92,7 +92,7 @@
       </nav>
       <div id="mobile-menu-wrap"></div>
       <div class="canvas-social">
-        <a href="tel:+346286896017"><i class="fa fa-phone fa-sm"></i></a>
+        <a href="tel:+34628689601"><i class="fa fa-phone fa-sm"></i></a>
         <a href="https://api.whatsapp.com/send?phone=34628689601"
           ><i class="fa fa-whatsapp"></i
         ></a>
@@ -196,9 +196,16 @@
       </div>
     </header>
     <!-- Header End -->
-
+    <!---------------------------- EN CONSTRUCCIÓN ---------------------------->
+    <section class="services-section spad">
+      <br /><br /><br /><br /><br /><br />
+      <h1 style="text-align: center; color: whitesmoke">PRÓXIMAMENTE...</h1>
+      <h2 style="text-align: center; color: whitesmoke">( En construcción )</h2>
+      <br /><br /><br />
+    </section>
+    <!-- 
     <!-- Breadcrumb Section Begin -->
-    <section
+    <!--<section
       class="breadcrumb-section set-bg"
       data-setbg="img/sumisionSueloAcortadaDark.png"
     >
@@ -206,11 +213,11 @@
         <div class="row">
           <div class="col-lg-12 text-center">
             <div class="breadcrumb-text">
-              <h2>Contacto</h2>
+              <h2>Técnicas</h2>
               <div class="bt-option">
                 <a href="./index.html">Inicio</a>
                 <a>Páginas</a>
-                <span>Contacto</span>
+                <span>Técnicas</span>
               </div>
             </div>
           </div>
@@ -219,70 +226,81 @@
     </section>
     <!-- Breadcrumb Section End -->
 
-    <!-- Contact Section Begin -->
-    <section class="contact-section spad">
+    <!-- Brands Section Begin -->
+    <section class="brands-section spad">
       <div class="container">
         <div class="row">
-          <div class="col-lg-6">
-            <div class="section-title contact-title">
-              <span>Sparta M.M.A</span>
-              <h2>Contacta con Nosotros</h2>
-            </div>
-            <div class="contact-widget">
-              <div class="cw-text">
-                <i class="fa fa-map-marker"></i>
-                <p>
-                  <a
-                    href="https://goo.gl/maps/io3SZ9hUKJmGDdsMA"
-                    target="”_blank”"
-                    >C/ Baleares, 11. 45005. Toledo</a
-                  ><br />
-                 
-                </p>
-              </div>
-              <div class="cw-text">
-                <i class="fa fa-mobile"></i>
-                <ul>
-                  <li><a href="tel:+34628689601">+34 628 68 96 01</a></li>
-                </ul>
-              </div>
-              <div class="cw-text email">
-                <i class="fa fa-envelope"></i>
-                <p>
-                  <a href="mailto:spartahellfighters@gmail.com"
-                    >spartahellfighters@gmail.com</a
-                  >
-                </p>
-              </div>
+          <div class="col-lg-12 text-center">
+            <div class="section-title">
+              <h2>Marcas con las que trabajamos</h2>
             </div>
           </div>
-          <div class="col-lg-6">
-            <div class="leave-comment">
-              <form
-                action="https://formsubmit.co/spartahellfighters@gmail.com"
-                method="POST"
-              >
-                <input type="hidden" name="_captcha" value="false" />
-                <input type="hidden" name="_template" value="box" />
-                <input
-                  type="hidden"
-                  name="_next"
-                  value="https://sanguino09.github.io/Spartan-MMA/"
-                />
-                <input type="text" name="fullname" placeholder="Nombre" />
-                <input type="email" name="email" placeholder="Correo" />
-                <textarea
-                  name="message"
-                  placeholder="Cuéntanos sobre ti"
-                ></textarea>
-                <button type="submit">Enviar</button>
-              </form>
-            </div>
+        </div>
+        <div class="row">
+          <div class="col-lg-3 col-md-3 col-sm-6 col-6">
+            <img src="https://via.placeholder.com/300x100?text=MAAT" alt="MAAT" class="img-fluid" />
+          </div>
+          <div class="col-lg-3 col-md-3 col-sm-6 col-6">
+            <img src="https://via.placeholder.com/300x100?text=MAAT+Promo" alt="Sparta MMA usa MAAT" class="img-fluid" />
+          </div>
+          <div class="col-lg-3 col-md-3 col-sm-6 col-6">
+            <img src="https://via.placeholder.com/300x100?text=Patch4Gi" alt="Patch4Gi" class="img-fluid" />
+          </div>
+          <div class="col-lg-3 col-md-3 col-sm-6 col-6">
+            <img src="https://via.placeholder.com/300x100?text=Custom+Fighter" alt="Custom Fighter" class="img-fluid" />
           </div>
         </div>
       </div>
     </section>
-    <!-- Contact Section End -->
+    <!-- Brands Section End -->
+    <!-- Get In Touch Section Begin -->
+    <div class="gettouch-section">
+      <div class="container">
+        <div class="row">
+          <div class="col-md-4">
+            <div class="gt-text">
+              <i class="fa fa-map-marker"></i>
+              <p>
+                <a
+                  href="https://goo.gl/maps/io3SZ9hUKJmGDdsMA"
+                  target="”_blank”"
+                  >C/ Baleares, 11. 45005. Toledo</a
+                ><br />
+                <a
+                  href="https://maps.app.goo.gl/BvAdANz6PkuxkCRR9"
+                  target="”_blank”"
+                  >C. de Granada, 19, 28007 Retiro, Madrid</a
+                >
+              </p>
+            </div>
+          </div>
+          <div class="col-md-4">
+            <div class="gt-text">
+              <i class="fa fa-mobile"></i>
+              <ul>
+                <li><a href="tel:+34628689601">+34 628 68 96 01</a></li>
+                <li>
+                  <a href="https://api.whatsapp.com/send?phone=34628689601"
+                    ><i class="fa fa-whatsapp abedul"></i>Whatsapp</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div class="col-md-4">
+            <div class="gt-text email">
+              <i class="fa fa-envelope"></i>
+              <p>
+                <a href="mailto:spartahellfighters@gmail.com"
+                  >spartahellfighters@gmail.com</a
+                >
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Get In Touch Section End -->
 
     <!-- Footer Section Begin -->
     <section class="footer-section">
@@ -407,8 +425,6 @@
                 </ul>
               </div>
               
-            
-
             </div>
           </div>
         </div>
@@ -439,13 +455,13 @@
 
     <!-- Search model Begin -->
     <!--<div class="search-model">
-      <div class="h-100 d-flex align-items-center justify-content-center">
-        <div class="search-close-switch">+</div>
-        <form class="search-model-form">
-          <input type="text" id="search-input" placeholder="Busca aquí..." />
-        </form>
-      </div>
-    </div>-->
+  <div class="h-100 d-flex align-items-center justify-content-center">
+    <div class="search-close-switch">+</div>
+    <form class="search-model-form">
+      <input type="text" id="search-input" placeholder="Busca aquí..." />
+    </form>
+  </div>
+</div>-->
     <!-- Search model end -->
 
     <!-- Js Plugins -->

--- a/mmaMerch.html
+++ b/mmaMerch.html
@@ -317,6 +317,7 @@
                 <li><a href="./class-timetable.html">Horario</a></li>
                 <li><a href="./gallery.html">Galería</a></li>
                 <li><a href="./store.html">Tienda</a></li>
+                <li><a href="./marcas.html">Marcas</a></li>
               </ul>
             </div>
           </div>

--- a/mmaPage.html
+++ b/mmaPage.html
@@ -672,6 +672,7 @@
                 <li><a href="./class-timetable.html">Horario</a></li>
                 <li><a href="./gallery.html">Galería</a></li>
                 <li><a href="./store.html">Tienda</a></li>
+                <li><a href="./marcas.html">Marcas</a></li>
               </ul>
             </div>
           </div>

--- a/prices.html
+++ b/prices.html
@@ -354,6 +354,7 @@
                   <li><a href="./class-timetable.html">Horario</a></li>
                   <li><a href="./gallery.html">Galería</a></li>
                   <li><a href="./store.html">Tienda</a></li>
+                <li><a href="./marcas.html">Marcas</a></li>
                 </ul>
               </div>
             </div>

--- a/privacidad.html
+++ b/privacidad.html
@@ -420,6 +420,7 @@
                 <li><a href="./class-timetable.html">Horario</a></li>
                 <li><a href="./gallery.html">Galería</a></li>
                 <li><a href="./store.html">Tienda</a></li>
+                <li><a href="./marcas.html">Marcas</a></li>
               </ul>
             </div>
           </div>

--- a/services.html
+++ b/services.html
@@ -482,6 +482,7 @@
                 <li><a href="./class-timetable.html">Horario</a></li>
                 <li><a href="./gallery.html">Galería</a></li>
                 <li><a href="./store.html">Tienda</a></li>
+                <li><a href="./marcas.html">Marcas</a></li>
               </ul>
             </div>
           </div>

--- a/store copy.html
+++ b/store copy.html
@@ -356,6 +356,7 @@
                 <li><a href="./class-timetable.html">Horario</a></li>
                 <li><a href="./gallery.html">Galería</a></li>
                 <li><a href="./store.html">Tienda</a></li>
+                <li><a href="./marcas.html">Marcas</a></li>
               </ul>
             </div>
           </div>

--- a/store.html
+++ b/store.html
@@ -434,6 +434,7 @@
                 <li><a href="./class-timetable.html">Horario</a></li>
                 <li><a href="./gallery.html">Galería</a></li>
                 <li><a href="./store.html">Tienda</a></li>
+                <li><a href="./marcas.html">Marcas</a></li>
               </ul>
             </div>
           </div>

--- a/team.html
+++ b/team.html
@@ -749,6 +749,7 @@
                 <li><a href="./class-timetable.html">Horario</a></li>
                 <li><a href="./gallery.html">Galería</a></li>
                 <li><a href="./store.html">Tienda</a></li>
+                <li><a href="./marcas.html">Marcas</a></li>
               </ul>
             </div>
           </div>

--- a/terminos.html
+++ b/terminos.html
@@ -659,6 +659,7 @@
                 <li><a href="./class-timetable.html">Horario</a></li>
                 <li><a href="./gallery.html">Galería</a></li>
                 <li><a href="./store.html">Tienda</a></li>
+                <li><a href="./marcas.html">Marcas</a></li>
               </ul>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- showcase partner logos on the homepage
- create standalone Marcas page with brand images
- link Marcas page from footer across the site
- replace local logo files with external placeholders to avoid binary assets

## Testing
- `npm test` *(fails: missing package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68ad6ef001bc832ba11366027a59b28e