### PR TITLE
Add QR navigation overlay for MAAT link

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3512,6 +3512,37 @@ a:hover {
   grid-row-gap: 3vh;
   height: inherit !important;
   }
-  
+
   .div1 { grid-area: 1 / 1 / 2 / 2; }
   .div2 { grid-area: 2 / 1 / 3 / 2; }
+
+/* QR overlay styles */
+#qr-overlay {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.9);
+  z-index: 9999;
+  text-align: center;
+}
+
+#qr-overlay .qr-content {
+  position: relative;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #fff;
+  padding: 0 15px;
+}
+
+#qr-overlay img {
+  max-width: 90%;
+  height: auto;
+  margin-bottom: 20px;
+}
+
+#qr-overlay a {
+  color: #e41c1f;
+}

--- a/js/main.js
+++ b/js/main.js
@@ -56,9 +56,25 @@
         gutter: 10
     });
 
+    // QR option and overlay
+    var qrNavItem = '<li><a href="#" class="qr-nav">QR</a></li>';
+    $('.nav-menu ul').append(qrNavItem);
+    $('.canvas-menu ul').append(qrNavItem);
+    var qrOverlay = '<div id="qr-overlay"><div class="qr-content"><img src="img/spartamma_qr.jpeg" alt="QR Sparta MMA"><p>Usa este enlace para entrar en la academia en MAAT y reservar <a href="https://maat-app.link/olDAAYpz7Vb" target="_blank">https://maat-app.link/olDAAYpz7Vb</a></p></div></div>';
+    $('body').append(qrOverlay);
+
+    $(document).on('click', '.qr-nav', function (e) {
+        e.preventDefault();
+        $('#qr-overlay').fadeIn();
+    });
+
+    $('#qr-overlay').on('click', function () {
+        $('#qr-overlay').fadeOut();
+    });
+
     /*------------------
-		Navigation
-	--------------------*/
+                Navigation
+        --------------------*/
     $(".mobile-menu").slicknav({
         prependTo: '#mobile-menu-wrap'
     });


### PR DESCRIPTION
## Summary
- add QR option to header and mobile navigation
- show overlay with academy QR code and MAAT reservation link

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b093f352f0832bad312c17c8775710