### PR TITLE
Remove duplicate QR nav items

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -62,11 +62,6 @@
     }).remove();
     var qrNavItem = '<li><a href="#" class="qr-nav" aria-label="Código QR"><i class="fa fa-qrcode"></i></a></li>';
     $('.nav-menu > ul, .canvas-menu > ul').append(qrNavItem);
-    var qrNavItem = '<li><a href="#" class="qr-nav" aria-label="Código QR"><i class="fa fa-qrcode"></i></a></li>';
-    $('.nav-menu > ul, .canvas-menu > ul').append(qrNavItem);
-    var qrNavItem = '<li><a href="#" class="qr-nav">QR</a></li>';
-    $('.nav-menu ul').append(qrNavItem);
-    $('.canvas-menu ul').append(qrNavItem);
     var qrOverlay = '<div id="qr-overlay"><div class="qr-content"><img src="img/spartamma_qr.jpeg" alt="QR Sparta MMA"><p>Usa este enlace para entrar en la academia en MAAT y reservar <a href="https://maat-app.link/olDAAYpz7Vb" target="_blank">https://maat-app.link/olDAAYpz7Vb</a></p></div></div>';
     $('body').append(qrOverlay);
 


### PR DESCRIPTION
## Summary
- dedupe QR option in navigation bar to show a single QR icon

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b09b124f48832ba9757ee44e46c61a