### PR TITLE
Add online payment options for disciplines and fix kids footer

### DIFF
--- a/grapPage.html
+++ b/grapPage.html
@@ -381,7 +381,7 @@ hacerlo con un método y en un ambiente personalizados.
        
       <div class="container">
         <div class="cta-form">
-          <h3>Reserva ya tu clase privada</h3>
+          <h3>Reserva ya y paga en mano</h3>
           <p>Escuela de Artes Marciales en Toledo - Sparta MMA</p>
         </div>
         <form action="https://api.web3forms.com/submit" method="POST">
@@ -430,6 +430,100 @@ hacerlo con un método y en un ambiente personalizados.
 
           <button type="submit">Reservar</button>
         </form>
+        <div class="online-reserve">
+          <div class="section-title">
+            <h3>o paga online</h3>
+          </div>
+          <div class="row justify-content-center">
+            <div class="col-lg-4 col-md-8">
+              <div class="ps-item">
+                <h3>Clase Suelta</h3>
+                <div class="pi-price">
+                  <h2>€ 15.0</h2>
+                </div>
+                <ul>
+                  <li>¡Tu clase de prueba!</li>
+                </ul>
+                <a
+                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02EyFE7HmWSisrwecITezV"
+                  class="primary-btn pricing-btn"
+                  >Apúntate ya</a
+                >
+              </div>
+            </div>
+            <div class="col-lg-4 col-md-8">
+              <div class="ps-item">
+                <h3>1 Disciplina</h3>
+                <div class="pi-price">
+                  <h2>€ 50.0</h2>
+                  <span>/ mes</span>
+                </div>
+                <ul>
+                  <li>MMA, BJJ o Grappling</li>
+                  <li>¡Elige con cuál quieres empezar!</li>
+                </ul>
+                <a
+                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02LgFE7HmWSisrIa0MFgoR"
+                  class="primary-btn pricing-btn"
+                  >Apúntate ya</a
+                >
+              </div>
+            </div>
+            <div class="col-lg-4 col-md-8">
+              <div class="ps-item">
+                <h3>2 Disciplinas</h3>
+                <div class="pi-price">
+                  <h2>€ 80.0</h2>
+                  <span>/ mes</span>
+                </div>
+                <ul>
+                  <li>MMA, BJJ o Grappling</li>
+                  <li>¡Combina las dos disciplinas que más te gusten!</li>
+                </ul>
+                <a
+                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02MMFE7HmWSisrfTmCt4Nc"
+                  class="primary-btn pricing-btn"
+                  >Apúntate ya</a
+                >
+              </div>
+            </div>
+            <div class="col-lg-4 col-md-8">
+              <div class="ps-item">
+                <h3>3 Disciplinas</h3>
+                <div class="pi-price">
+                  <h2>€ 100.0</h2>
+                  <span>/ mes</span>
+                </div>
+                <ul>
+                  <li>Entrena todas las disciplinas</li>
+                </ul>
+                <a
+                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02MaFE7HmWSisr3GlGmY3I"
+                  class="primary-btn pricing-btn"
+                  >Apúntate ya</a
+                >
+              </div>
+            </div>
+            <div class="col-lg-4 col-md-8">
+              <div class="ps-item">
+                <h3>BJJ Spartan Kids</h3>
+                <h3>Infantiles (2 días / semana)</h3>
+                <div class="pi-price">
+                  <h2>€ 50.0</h2>
+                  <span>/ mes</span>
+                </div>
+                <ul>
+                  <li>2 días por semana</li>
+                </ul>
+                <a
+                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02N4FE7HmWSisr9px4l123"
+                  class="primary-btn pricing-btn"
+                  >Apúntate ya</a
+                >
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </section>
     <!-- Timetable Section Begin -->

--- a/jjbPage.html
+++ b/jjbPage.html
@@ -500,7 +500,7 @@ Aquí, cada clase es un paso hacia la superación personal, en un ambiente segur
       </div>
       <div class="container">
         <div class="cta-form">
-          <h3>Reserva ya tu clase privada</h3>
+          <h3>Reserva ya y paga en mano</h3>
           <p>Escuela de Artes Marciales en Toledo - Sparta MMA</p>
         </div>
         <form action="https://api.web3forms.com/submit" method="POST">
@@ -549,6 +549,100 @@ Aquí, cada clase es un paso hacia la superación personal, en un ambiente segur
 
           <button type="submit">Reservar</button>
         </form>
+        <div class="online-reserve">
+          <div class="section-title">
+            <h3>o paga online</h3>
+          </div>
+          <div class="row justify-content-center">
+            <div class="col-lg-4 col-md-8">
+              <div class="ps-item">
+                <h3>Clase Suelta</h3>
+                <div class="pi-price">
+                  <h2>€ 15.0</h2>
+                </div>
+                <ul>
+                  <li>¡Tu clase de prueba!</li>
+                </ul>
+                <a
+                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02EyFE7HmWSisrwecITezV"
+                  class="primary-btn pricing-btn"
+                  >Apúntate ya</a
+                >
+              </div>
+            </div>
+            <div class="col-lg-4 col-md-8">
+              <div class="ps-item">
+                <h3>1 Disciplina</h3>
+                <div class="pi-price">
+                  <h2>€ 50.0</h2>
+                  <span>/ mes</span>
+                </div>
+                <ul>
+                  <li>MMA, BJJ o Grappling</li>
+                  <li>¡Elige con cuál quieres empezar!</li>
+                </ul>
+                <a
+                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02LgFE7HmWSisrIa0MFgoR"
+                  class="primary-btn pricing-btn"
+                  >Apúntate ya</a
+                >
+              </div>
+            </div>
+            <div class="col-lg-4 col-md-8">
+              <div class="ps-item">
+                <h3>2 Disciplinas</h3>
+                <div class="pi-price">
+                  <h2>€ 80.0</h2>
+                  <span>/ mes</span>
+                </div>
+                <ul>
+                  <li>MMA, BJJ o Grappling</li>
+                  <li>¡Combina las dos disciplinas que más te gusten!</li>
+                </ul>
+                <a
+                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02MMFE7HmWSisrfTmCt4Nc"
+                  class="primary-btn pricing-btn"
+                  >Apúntate ya</a
+                >
+              </div>
+            </div>
+            <div class="col-lg-4 col-md-8">
+              <div class="ps-item">
+                <h3>3 Disciplinas</h3>
+                <div class="pi-price">
+                  <h2>€ 100.0</h2>
+                  <span>/ mes</span>
+                </div>
+                <ul>
+                  <li>Entrena todas las disciplinas</li>
+                </ul>
+                <a
+                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02MaFE7HmWSisr3GlGmY3I"
+                  class="primary-btn pricing-btn"
+                  >Apúntate ya</a
+                >
+              </div>
+            </div>
+            <div class="col-lg-4 col-md-8">
+              <div class="ps-item">
+                <h3>BJJ Spartan Kids</h3>
+                <h3>Infantiles (2 días / semana)</h3>
+                <div class="pi-price">
+                  <h2>€ 50.0</h2>
+                  <span>/ mes</span>
+                </div>
+                <ul>
+                  <li>2 días por semana</li>
+                </ul>
+                <a
+                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02N4FE7HmWSisr9px4l123"
+                  class="primary-btn pricing-btn"
+                  >Apúntate ya</a
+                >
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </section>
     <!-- Clases privadas End -->

--- a/kidsPage.html
+++ b/kidsPage.html
@@ -300,6 +300,7 @@
                 <li><a href="./jjbPage.html">Brazilian Jiujitsu</a></li>
                 <li><a href="./grapPage.html">Grappling </a></li>
                 <li><a href="./kidsPage.html">Spartan Kids</a></li>
+                <li><a href="./extrasPage.html">Extras</a></li>
                 <li><a href="./team.html">Instructor</a></li>
                 <li><a href="./services.html">Técnicas</a></li>
                 <li><a href="./class-timetable.html">Horario</a></li>
@@ -324,13 +325,82 @@
             <div class="fs-widget">
               <h4>Logos</h4>
               <div class="fw-recent">
-                <div class="fr-item">
-                  <a href="#"><img src="img/footer1.jpg" load="lazy" alt="" /></a>
-                </div>
-                <div class="fr-item">
-                  <a href="#"><img src="img/footer2.jpg" load="lazy" alt="" /></a>
-                </div>
+                <a href="./mmaPage.html" target="_blank"
+                  ><img src="img/spartaWhite.jpeg" load="lazy" class="gymLogo"
+                /></a>
+                &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp<a
+                  href="./grapPage.html"
+                  target="_blank"
+                  ><img src="img/hellFighters.png" load="lazy" class="gymLogo"
+                /></a>
+                <h6>
+                  <a href="./mmaPage.html" target="_blank">Sparta MMA</a> &nbsp
+                  &nbsp &nbsp &nbsp &nbsp
+                  <a href="./grapPage.html" target="_blank"
+                    >Sparta Hellfighters</a
+                  >
+                </h6>
               </div>
+            </div>
+            <div class="fs-widget">
+              <h4>Centros</h4>
+              <div class="fw-recent">
+                <a
+                  href="https://www.instagram.com/gimnasio_limite/?hl=es"
+                  target="_blank"
+                  ><img src="img/fullLogoWhite.png" load="lazy" class="gymLogo"
+                /></a>
+                <h6>
+                  <a
+                    href="https://www.instagram.com/gimnasio_limite/?hl=es"
+                    target="_blank"
+                    >Sede Central</a
+                  >
+                </h6>
+                <ul>
+                  <li>M.M.A / BJJ / Grappling</li>
+                  <li>C/ Sancho Panza, 11. 45007 Toledo (polígono industrial)</li>
+                </ul>
+              </div>
+              <div class="fw-recent">
+                <a
+                  href="https://www.instagram.com/gimnasio_limite/?hl=es"
+                  target="_blank"
+                  ><img src="img/gymLimite.jpg" load="lazy" class="gymLogo"
+                /></a>
+                <h6>
+                  <a
+                    href="https://www.instagram.com/gimnasio_limite/?hl=es"
+                    target="_blank"
+                    >Gimnasio Límite | Filial Toledo</a
+                  >
+                </h6>
+                <ul>
+                  <li>M.M.A / BJJ / Grappling</li>
+                  <li>C/ Baleares, 11. 45005 Toledo</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-lg-12 text-center">
+            <div class="copyright-text">
+              <p>
+                <!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
+                Copyright &copy;
+                <script>
+                  document.write(new Date().getFullYear());
+                </script>
+                Todos los derechos reservados | ProyectoSanguino con
+                <a
+                  href="https://colorlib.com"
+                  style="color: #a9a9a9 !important"
+                  target="_blank"
+                  >Colorlib</a
+                >
+                <!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
+              </p>
             </div>
           </div>
         </div>

--- a/mmaPage.html
+++ b/mmaPage.html
@@ -449,7 +449,7 @@
       </div>
       <div class="container">
         <div class="cta-form">
-          <h3>Reserva ya tu clase privada</h3>
+          <h3>Reserva ya y paga en mano</h3>
           <p>Escuela de Artes Marciales en Toledo - Sparta MMA</p>
         </div>
         <form action="https://api.web3forms.com/submit" method="POST">
@@ -498,6 +498,100 @@
 
           <button type="submit">Reservar</button>
         </form>
+        <div class="online-reserve">
+          <div class="section-title">
+            <h3>o paga online</h3>
+          </div>
+          <div class="row justify-content-center">
+            <div class="col-lg-4 col-md-8">
+              <div class="ps-item">
+                <h3>Clase Suelta</h3>
+                <div class="pi-price">
+                  <h2>€ 15.0</h2>
+                </div>
+                <ul>
+                  <li>¡Tu clase de prueba!</li>
+                </ul>
+                <a
+                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02EyFE7HmWSisrwecITezV"
+                  class="primary-btn pricing-btn"
+                  >Apúntate ya</a
+                >
+              </div>
+            </div>
+            <div class="col-lg-4 col-md-8">
+              <div class="ps-item">
+                <h3>1 Disciplina</h3>
+                <div class="pi-price">
+                  <h2>€ 50.0</h2>
+                  <span>/ mes</span>
+                </div>
+                <ul>
+                  <li>MMA, BJJ o Grappling</li>
+                  <li>¡Elige con cuál quieres empezar!</li>
+                </ul>
+                <a
+                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02LgFE7HmWSisrIa0MFgoR"
+                  class="primary-btn pricing-btn"
+                  >Apúntate ya</a
+                >
+              </div>
+            </div>
+            <div class="col-lg-4 col-md-8">
+              <div class="ps-item">
+                <h3>2 Disciplinas</h3>
+                <div class="pi-price">
+                  <h2>€ 80.0</h2>
+                  <span>/ mes</span>
+                </div>
+                <ul>
+                  <li>MMA, BJJ o Grappling</li>
+                  <li>¡Combina las dos disciplinas que más te gusten!</li>
+                </ul>
+                <a
+                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02MMFE7HmWSisrfTmCt4Nc"
+                  class="primary-btn pricing-btn"
+                  >Apúntate ya</a
+                >
+              </div>
+            </div>
+            <div class="col-lg-4 col-md-8">
+              <div class="ps-item">
+                <h3>3 Disciplinas</h3>
+                <div class="pi-price">
+                  <h2>€ 100.0</h2>
+                  <span>/ mes</span>
+                </div>
+                <ul>
+                  <li>Entrena todas las disciplinas</li>
+                </ul>
+                <a
+                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02MaFE7HmWSisr3GlGmY3I"
+                  class="primary-btn pricing-btn"
+                  >Apúntate ya</a
+                >
+              </div>
+            </div>
+            <div class="col-lg-4 col-md-8">
+              <div class="ps-item">
+                <h3>BJJ Spartan Kids</h3>
+                <h3>Infantiles (2 días / semana)</h3>
+                <div class="pi-price">
+                  <h2>€ 50.0</h2>
+                  <span>/ mes</span>
+                </div>
+                <ul>
+                  <li>2 días por semana</li>
+                </ul>
+                <a
+                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02N4FE7HmWSisr9px4l123"
+                  class="primary-btn pricing-btn"
+                  >Apúntate ya</a
+                >
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- Reworded private class CTA and added online payment options to MMA, Grappling, and BJJ discipline pages.
- Restored missing links and full footer structure on the Spartan Kids page.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a1a6ffa4832ba983383f3084b152