### PR TITLE
Fix online booking section on discipline pages

### DIFF
--- a/grapPage.html
+++ b/grapPage.html
@@ -430,7 +430,9 @@ hacerlo con un método y en un ambiente personalizados.
 
           <button type="submit">Reservar</button>
         </form>
-        <div class="online-reserve">
+      </div>
+      <div class="online-reserve">
+        <div class="container">
           <div class="section-title">
             <h3>o paga online</h3>
           </div>

--- a/jjbPage.html
+++ b/jjbPage.html
@@ -549,7 +549,9 @@ Aquí, cada clase es un paso hacia la superación personal, en un ambiente segur
 
           <button type="submit">Reservar</button>
         </form>
-        <div class="online-reserve">
+      </div>
+      <div class="online-reserve">
+        <div class="container">
           <div class="section-title">
             <h3>o paga online</h3>
           </div>

--- a/mmaPage.html
+++ b/mmaPage.html
@@ -498,7 +498,9 @@
 
           <button type="submit">Reservar</button>
         </form>
-        <div class="online-reserve">
+      </div>
+      <div class="online-reserve">
+        <div class="container">
           <div class="section-title">
             <h3>o paga online</h3>
           </div>


### PR DESCRIPTION
## Summary
- Move online reservation block outside "Reserva ya y paga en mano" forms on BJJ, MMA, and Grappling pages
- Wrap new online payment area in its own container for proper layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a397e300832b9497d8e611c75b04