### PR TITLE
Fix online booking section on discipline pages

### DIFF
--- a/grapPage.html
+++ b/grapPage.html
@@ -430,97 +430,81 @@ hacerlo con un método y en un ambiente personalizados.
 
           <button type="submit">Reservar</button>
         </form>
-        <div class="online-reserve">
-          <div class="section-title">
-            <h3>o paga online</h3>
+      </div>
+    </section>
+    <section class="pricing-section spad online-reserve">
+      <div class="container">
+        <div class="section-title">
+          <h3>o paga online</h3>
+        </div>
+        <div class="row justify-content-center">
+          <div class="col-lg-4 col-md-8">
+            <div class="ps-item">
+              <h3>Clase Suelta</h3>
+              <div class="pi-price">
+                <h2>€ 15.0</h2>
+              </div>
+              <ul>
+                <li>¡Tu clase de prueba!</li>
+              </ul>
+              <a
+                href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02EyFE7HmWSisrwecITezV"
+                class="primary-btn pricing-btn"
+                >Apúntate ya</a
+              >
+            </div>
           </div>
-          <div class="row justify-content-center">
-            <div class="col-lg-4 col-md-8">
-              <div class="ps-item">
-                <h3>Clase Suelta</h3>
-                <div class="pi-price">
-                  <h2>€ 15.0</h2>
-                </div>
-                <ul>
-                  <li>¡Tu clase de prueba!</li>
-                </ul>
-                <a
-                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02EyFE7HmWSisrwecITezV"
-                  class="primary-btn pricing-btn"
-                  >Apúntate ya</a
-                >
+          <div class="col-lg-4 col-md-8">
+            <div class="ps-item">
+              <h3>1 Disciplina</h3>
+              <div class="pi-price">
+                <h2>€ 50.0</h2>
+                <span>/ mes</span>
               </div>
+              <ul>
+                <li>MMA, BJJ o Grappling</li>
+                <li>¡Elige con cuál quieres empezar!</li>
+              </ul>
+              <a
+                href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02LgFE7HmWSisrIa0MFgoR"
+                class="primary-btn pricing-btn"
+                >Apúntate ya</a
+              >
             </div>
-            <div class="col-lg-4 col-md-8">
-              <div class="ps-item">
-                <h3>1 Disciplina</h3>
-                <div class="pi-price">
-                  <h2>€ 50.0</h2>
-                  <span>/ mes</span>
-                </div>
-                <ul>
-                  <li>MMA, BJJ o Grappling</li>
-                  <li>¡Elige con cuál quieres empezar!</li>
-                </ul>
-                <a
-                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02LgFE7HmWSisrIa0MFgoR"
-                  class="primary-btn pricing-btn"
-                  >Apúntate ya</a
-                >
+          </div>
+          <div class="col-lg-4 col-md-8">
+            <div class="ps-item">
+              <h3>2 Disciplinas</h3>
+              <div class="pi-price">
+                <h2>€ 80.0</h2>
+                <span>/ mes</span>
               </div>
+              <ul>
+                <li>MMA, BJJ o Grappling</li>
+                <li>¡Combina las dos disciplinas que más te gusten!</li>
+              </ul>
+              <a
+                href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02MMFE7HmWSisrfTmCt4Nc"
+                class="primary-btn pricing-btn"
+                >Apúntate ya</a
+              >
             </div>
-            <div class="col-lg-4 col-md-8">
-              <div class="ps-item">
-                <h3>2 Disciplinas</h3>
-                <div class="pi-price">
-                  <h2>€ 80.0</h2>
-                  <span>/ mes</span>
-                </div>
-                <ul>
-                  <li>MMA, BJJ o Grappling</li>
-                  <li>¡Combina las dos disciplinas que más te gusten!</li>
-                </ul>
-                <a
-                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02MMFE7HmWSisrfTmCt4Nc"
-                  class="primary-btn pricing-btn"
-                  >Apúntate ya</a
-                >
+          </div>
+          <div class="col-lg-4 col-md-8">
+            <div class="ps-item">
+              <h3>3 Disciplinas</h3>
+              <div class="pi-price">
+                <h2>€ 100.0</h2>
+                <span>/ mes</span>
               </div>
-            </div>
-            <div class="col-lg-4 col-md-8">
-              <div class="ps-item">
-                <h3>3 Disciplinas</h3>
-                <div class="pi-price">
-                  <h2>€ 100.0</h2>
-                  <span>/ mes</span>
-                </div>
-                <ul>
-                  <li>Entrena todas las disciplinas</li>
-                </ul>
-                <a
-                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02MaFE7HmWSisr3GlGmY3I"
-                  class="primary-btn pricing-btn"
-                  >Apúntate ya</a
-                >
-              </div>
-            </div>
-            <div class="col-lg-4 col-md-8">
-              <div class="ps-item">
-                <h3>BJJ Spartan Kids</h3>
-                <h3>Infantiles (2 días / semana)</h3>
-                <div class="pi-price">
-                  <h2>€ 50.0</h2>
-                  <span>/ mes</span>
-                </div>
-                <ul>
-                  <li>2 días por semana</li>
-                </ul>
-                <a
-                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02N4FE7HmWSisr9px4l123"
-                  class="primary-btn pricing-btn"
-                  >Apúntate ya</a
-                >
-              </div>
+              <ul>
+                <li>Entrena todas las disciplinas</li>
+              </ul>
+              <a
+                href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02MaFE7HmWSisr3GlGmY3I"
+                class="primary-btn pricing-btn"
+                >Apúntate ya</a
+              >
             </div>
           </div>
         </div>

--- a/jjbPage.html
+++ b/jjbPage.html
@@ -549,97 +549,81 @@ Aquí, cada clase es un paso hacia la superación personal, en un ambiente segur
 
           <button type="submit">Reservar</button>
         </form>
-        <div class="online-reserve">
-          <div class="section-title">
-            <h3>o paga online</h3>
+      </div>
+    </section>
+    <section class="pricing-section spad online-reserve">
+      <div class="container">
+        <div class="section-title">
+          <h3>o paga online</h3>
+        </div>
+        <div class="row justify-content-center">
+          <div class="col-lg-4 col-md-8">
+            <div class="ps-item">
+              <h3>Clase Suelta</h3>
+              <div class="pi-price">
+                <h2>€ 15.0</h2>
+              </div>
+              <ul>
+                <li>¡Tu clase de prueba!</li>
+              </ul>
+              <a
+                href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02EyFE7HmWSisrwecITezV"
+                class="primary-btn pricing-btn"
+                >Apúntate ya</a
+              >
+            </div>
           </div>
-          <div class="row justify-content-center">
-            <div class="col-lg-4 col-md-8">
-              <div class="ps-item">
-                <h3>Clase Suelta</h3>
-                <div class="pi-price">
-                  <h2>€ 15.0</h2>
-                </div>
-                <ul>
-                  <li>¡Tu clase de prueba!</li>
-                </ul>
-                <a
-                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02EyFE7HmWSisrwecITezV"
-                  class="primary-btn pricing-btn"
-                  >Apúntate ya</a
-                >
+          <div class="col-lg-4 col-md-8">
+            <div class="ps-item">
+              <h3>1 Disciplina</h3>
+              <div class="pi-price">
+                <h2>€ 50.0</h2>
+                <span>/ mes</span>
               </div>
+              <ul>
+                <li>MMA, BJJ o Grappling</li>
+                <li>¡Elige con cuál quieres empezar!</li>
+              </ul>
+              <a
+                href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02LgFE7HmWSisrIa0MFgoR"
+                class="primary-btn pricing-btn"
+                >Apúntate ya</a
+              >
             </div>
-            <div class="col-lg-4 col-md-8">
-              <div class="ps-item">
-                <h3>1 Disciplina</h3>
-                <div class="pi-price">
-                  <h2>€ 50.0</h2>
-                  <span>/ mes</span>
-                </div>
-                <ul>
-                  <li>MMA, BJJ o Grappling</li>
-                  <li>¡Elige con cuál quieres empezar!</li>
-                </ul>
-                <a
-                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02LgFE7HmWSisrIa0MFgoR"
-                  class="primary-btn pricing-btn"
-                  >Apúntate ya</a
-                >
+          </div>
+          <div class="col-lg-4 col-md-8">
+            <div class="ps-item">
+              <h3>2 Disciplinas</h3>
+              <div class="pi-price">
+                <h2>€ 80.0</h2>
+                <span>/ mes</span>
               </div>
+              <ul>
+                <li>MMA, BJJ o Grappling</li>
+                <li>¡Combina las dos disciplinas que más te gusten!</li>
+              </ul>
+              <a
+                href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02MMFE7HmWSisrfTmCt4Nc"
+                class="primary-btn pricing-btn"
+                >Apúntate ya</a
+              >
             </div>
-            <div class="col-lg-4 col-md-8">
-              <div class="ps-item">
-                <h3>2 Disciplinas</h3>
-                <div class="pi-price">
-                  <h2>€ 80.0</h2>
-                  <span>/ mes</span>
-                </div>
-                <ul>
-                  <li>MMA, BJJ o Grappling</li>
-                  <li>¡Combina las dos disciplinas que más te gusten!</li>
-                </ul>
-                <a
-                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02MMFE7HmWSisrfTmCt4Nc"
-                  class="primary-btn pricing-btn"
-                  >Apúntate ya</a
-                >
+          </div>
+          <div class="col-lg-4 col-md-8">
+            <div class="ps-item">
+              <h3>3 Disciplinas</h3>
+              <div class="pi-price">
+                <h2>€ 100.0</h2>
+                <span>/ mes</span>
               </div>
-            </div>
-            <div class="col-lg-4 col-md-8">
-              <div class="ps-item">
-                <h3>3 Disciplinas</h3>
-                <div class="pi-price">
-                  <h2>€ 100.0</h2>
-                  <span>/ mes</span>
-                </div>
-                <ul>
-                  <li>Entrena todas las disciplinas</li>
-                </ul>
-                <a
-                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02MaFE7HmWSisr3GlGmY3I"
-                  class="primary-btn pricing-btn"
-                  >Apúntate ya</a
-                >
-              </div>
-            </div>
-            <div class="col-lg-4 col-md-8">
-              <div class="ps-item">
-                <h3>BJJ Spartan Kids</h3>
-                <h3>Infantiles (2 días / semana)</h3>
-                <div class="pi-price">
-                  <h2>€ 50.0</h2>
-                  <span>/ mes</span>
-                </div>
-                <ul>
-                  <li>2 días por semana</li>
-                </ul>
-                <a
-                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02N4FE7HmWSisr9px4l123"
-                  class="primary-btn pricing-btn"
-                  >Apúntate ya</a
-                >
-              </div>
+              <ul>
+                <li>Entrena todas las disciplinas</li>
+              </ul>
+              <a
+                href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02MaFE7HmWSisr3GlGmY3I"
+                class="primary-btn pricing-btn"
+                >Apúntate ya</a
+              >
             </div>
           </div>
         </div>

--- a/kidsPage.html
+++ b/kidsPage.html
@@ -266,7 +266,101 @@
         </ul>
         <br /><br />
       </div>
-      
+      <div class="container">
+        <div class="cta-form">
+          <h3>Reserva ya y paga en mano</h3>
+          <p>Escuela de Artes Marciales en Toledo - Sparta MMA</p>
+        </div>
+        <form action="https://api.web3forms.com/submit" method="POST">
+          <input
+            type="hidden"
+            name="access_key"
+            value="d1ba759c-c0d9-42e0-853e-7d3645a10102"
+          />
+          <input
+            type="hidden"
+            name="subject"
+            value="Nueva Reserva de Clase Privada Spartan Kids"
+          />
+          <input
+            type="text"
+            placeholder="Name"
+            class="form__input"
+            name="nombre"
+            id="name"
+          />
+          <input type="hidden" name="from_name" value="Notificación" />
+          <input
+            type="hidden"
+            name="redirect"
+            value="https://www.spartamma.es/"
+          />
+          <label for="name" class="form__label">Nombre</label>
+
+          <input
+            type="email"
+            placeholder="Email"
+            class="form__input"
+            id="email"
+            name="email"
+          />
+          <label for="email" class="form__label">Correo</label>
+
+          <input
+            type="number"
+            placeholder="Subject"
+            class="form__input"
+            id="subject"
+            name="teléfono"
+          />
+          <label for="subject" class="form__label">Teléfono</label>
+
+          <button type="submit">Reservar</button>
+        </form>
+      </div>
+    </section>
+    <section class="pricing-section spad online-reserve">
+      <div class="container">
+        <div class="section-title">
+          <h3>o paga online</h3>
+        </div>
+        <div class="row justify-content-center">
+          <div class="col-lg-4 col-md-8">
+            <div class="ps-item">
+              <h3>Clase Suelta</h3>
+              <div class="pi-price">
+                <h2>€ 15.0</h2>
+              </div>
+              <ul>
+                <li>¡Tu clase de prueba!</li>
+              </ul>
+              <a
+                href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02EyFE7HmWSisrwecITezV"
+                class="primary-btn pricing-btn"
+                >Apúntate ya</a
+              >
+            </div>
+          </div>
+          <div class="col-lg-4 col-md-8">
+            <div class="ps-item">
+              <h3>BJJ Spartan Kids</h3>
+              <h3>Infantiles (2 días / semana)</h3>
+              <div class="pi-price">
+                <h2>€ 50.0</h2>
+                <span>/ mes</span>
+              </div>
+              <ul>
+                <li>2 días por semana</li>
+              </ul>
+              <a
+                href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02N4FE7HmWSisr9px4l123"
+                class="primary-btn pricing-btn"
+                >Apúntate ya</a
+              >
+            </div>
+          </div>
+        </div>
+      </div>
     </section>
     <!-- Private Classes Section End -->
 

--- a/mmaPage.html
+++ b/mmaPage.html
@@ -498,97 +498,81 @@
 
           <button type="submit">Reservar</button>
         </form>
-        <div class="online-reserve">
-          <div class="section-title">
-            <h3>o paga online</h3>
+      </div>
+    </section>
+    <section class="pricing-section spad online-reserve">
+      <div class="container">
+        <div class="section-title">
+          <h3>o paga online</h3>
+        </div>
+        <div class="row justify-content-center">
+          <div class="col-lg-4 col-md-8">
+            <div class="ps-item">
+              <h3>Clase Suelta</h3>
+              <div class="pi-price">
+                <h2>€ 15.0</h2>
+              </div>
+              <ul>
+                <li>¡Tu clase de prueba!</li>
+              </ul>
+              <a
+                href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02EyFE7HmWSisrwecITezV"
+                class="primary-btn pricing-btn"
+                >Apúntate ya</a
+              >
+            </div>
           </div>
-          <div class="row justify-content-center">
-            <div class="col-lg-4 col-md-8">
-              <div class="ps-item">
-                <h3>Clase Suelta</h3>
-                <div class="pi-price">
-                  <h2>€ 15.0</h2>
-                </div>
-                <ul>
-                  <li>¡Tu clase de prueba!</li>
-                </ul>
-                <a
-                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02EyFE7HmWSisrwecITezV"
-                  class="primary-btn pricing-btn"
-                  >Apúntate ya</a
-                >
+          <div class="col-lg-4 col-md-8">
+            <div class="ps-item">
+              <h3>1 Disciplina</h3>
+              <div class="pi-price">
+                <h2>€ 50.0</h2>
+                <span>/ mes</span>
               </div>
+              <ul>
+                <li>MMA, BJJ o Grappling</li>
+                <li>¡Elige con cuál quieres empezar!</li>
+              </ul>
+              <a
+                href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02LgFE7HmWSisrIa0MFgoR"
+                class="primary-btn pricing-btn"
+                >Apúntate ya</a
+              >
             </div>
-            <div class="col-lg-4 col-md-8">
-              <div class="ps-item">
-                <h3>1 Disciplina</h3>
-                <div class="pi-price">
-                  <h2>€ 50.0</h2>
-                  <span>/ mes</span>
-                </div>
-                <ul>
-                  <li>MMA, BJJ o Grappling</li>
-                  <li>¡Elige con cuál quieres empezar!</li>
-                </ul>
-                <a
-                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02LgFE7HmWSisrIa0MFgoR"
-                  class="primary-btn pricing-btn"
-                  >Apúntate ya</a
-                >
+          </div>
+          <div class="col-lg-4 col-md-8">
+            <div class="ps-item">
+              <h3>2 Disciplinas</h3>
+              <div class="pi-price">
+                <h2>€ 80.0</h2>
+                <span>/ mes</span>
               </div>
+              <ul>
+                <li>MMA, BJJ o Grappling</li>
+                <li>¡Combina las dos disciplinas que más te gusten!</li>
+              </ul>
+              <a
+                href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02MMFE7HmWSisrfTmCt4Nc"
+                class="primary-btn pricing-btn"
+                >Apúntate ya</a
+              >
             </div>
-            <div class="col-lg-4 col-md-8">
-              <div class="ps-item">
-                <h3>2 Disciplinas</h3>
-                <div class="pi-price">
-                  <h2>€ 80.0</h2>
-                  <span>/ mes</span>
-                </div>
-                <ul>
-                  <li>MMA, BJJ o Grappling</li>
-                  <li>¡Combina las dos disciplinas que más te gusten!</li>
-                </ul>
-                <a
-                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02MMFE7HmWSisrfTmCt4Nc"
-                  class="primary-btn pricing-btn"
-                  >Apúntate ya</a
-                >
+          </div>
+          <div class="col-lg-4 col-md-8">
+            <div class="ps-item">
+              <h3>3 Disciplinas</h3>
+              <div class="pi-price">
+                <h2>€ 100.0</h2>
+                <span>/ mes</span>
               </div>
-            </div>
-            <div class="col-lg-4 col-md-8">
-              <div class="ps-item">
-                <h3>3 Disciplinas</h3>
-                <div class="pi-price">
-                  <h2>€ 100.0</h2>
-                  <span>/ mes</span>
-                </div>
-                <ul>
-                  <li>Entrena todas las disciplinas</li>
-                </ul>
-                <a
-                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02MaFE7HmWSisr3GlGmY3I"
-                  class="primary-btn pricing-btn"
-                  >Apúntate ya</a
-                >
-              </div>
-            </div>
-            <div class="col-lg-4 col-md-8">
-              <div class="ps-item">
-                <h3>BJJ Spartan Kids</h3>
-                <h3>Infantiles (2 días / semana)</h3>
-                <div class="pi-price">
-                  <h2>€ 50.0</h2>
-                  <span>/ mes</span>
-                </div>
-                <ul>
-                  <li>2 días por semana</li>
-                </ul>
-                <a
-                  href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02N4FE7HmWSisr9px4l123"
-                  class="primary-btn pricing-btn"
-                  >Apúntate ya</a
-                >
-              </div>
+              <ul>
+                <li>Entrena todas las disciplinas</li>
+              </ul>
+              <a
+                href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02MaFE7HmWSisr3GlGmY3I"
+                class="primary-btn pricing-btn"
+                >Apúntate ya</a
+              >
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Move online reservation block outside "Reserva ya y paga en mano" forms on BJJ, MMA, and Grappling pages and drop Spartan Kids plan
- Add booking form and dedicated online payment area for Spartan Kids with single-class and BJJ kids options

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a397e300832b9497d8e611c75b04