### PR TITLE
Fix spacing below extras reserve buttons

### DIFF
--- a/css/style2.css
+++ b/css/style2.css
@@ -215,6 +215,7 @@ html .form__input::-moz-placeholder {
 
 .single-blog-item .primary-btn.pricing-btn {
   margin-top: 15px;
+  margin-bottom: 20px;
 }
 html .form__input::placeholder {
   display: none;


### PR DESCRIPTION
## Summary
- add bottom margin to extras page reserve buttons for better spacing on mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1eeef0384832b9abeef59e86939dd