### PR TITLE
Fix schedule tables to show weekdays only

### DIFF
--- a/class-timetable.html
+++ b/class-timetable.html
@@ -293,13 +293,6 @@ td{padding-top:5px !important;padding-bottom:5px !important;}}
                     <td class="hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
                     <td class="dark-bg hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
                     <td class="hover-bg ts-meta" data-tsmeta="mma"><span>MMA Sparring</span></td>
-
-                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
-                    <td class="hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
-                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
-                    <td class="hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
-                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="mma"><span>MMA Sparring</span></td>
-
                   </tr>
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">17:00h - 18:00h</span></td>
@@ -311,19 +304,12 @@ td{padding-top:5px !important;padding-bottom:5px !important;}}
                   </tr>
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">18:00h - 19:00h</span></td>
- 
+
                     <td class="blank-td ts-meta" data-tsmeta="mma"><span></span></td>
                     <td class="dark-bg blank-td ts-meta" data-tsmeta="mma"><span></span></td>
                     <td class="blank-td ts-meta" data-tsmeta="mma"><span></span></td>
                     <td class="dark-bg blank-td ts-meta" data-tsmeta="mma"><span></span></td>
                     <td class="hover-bg ts-meta" data-tsmeta="mma"><span>MMA Sparring</span></td>
-
-                    <td class="dark-bg blank-td ts-meta" data-tsmeta="mma"><span></span></td>
-                    <td class="blank-td ts-meta" data-tsmeta="mma"><span></span></td>
-                    <td class="dark-bg blank-td ts-meta" data-tsmeta="mma"><span></span></td>
-                    <td class="blank-td ts-meta" data-tsmeta="mma"><span></span></td>
-                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="mma"><span>MMA Sparring</span></td>
- 
                   </tr>
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">19:00h - 20:00h</span></td>
@@ -335,19 +321,12 @@ td{padding-top:5px !important;padding-bottom:5px !important;}}
                   </tr>
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">20:00h - 21:00h</span></td>
- 
+
                     <td class="hover-bg ts-meta" data-tsmeta="bjj"><span>BJJ</span></td>
                     <td class="dark-bg hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
                     <td class="hover-bg ts-meta" data-tsmeta="bjj"><span>BJJ</span></td>
                     <td class="dark-bg hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
                     <td class="blank-td ts-meta" data-tsmeta="mma"><span></span></td>
-
-                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="bjj"><span>BJJ</span></td>
-                    <td class="hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
-                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="bjj"><span>BJJ</span></td>
-                    <td class="hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
-                    <td class="dark-bg blank-td ts-meta" data-tsmeta="mma"><span></span></td>
- 
                   </tr>
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">21:00h - 22:00h</span></td>

--- a/grapPage.html
+++ b/grapPage.html
@@ -522,19 +522,12 @@ hacerlo con un método y en un ambiente personalizados.
                 <tbody>
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">10:00h - 11:00h</span></td>
- 
+
                     <td class="dark-bg blank-td"><span></span></td>
                     <td class="hover-bg ts-meta" data-tsmeta="grap"><span>Grappling</span></td>
                     <td class="dark-bg blank-td"><span></span></td>
                     <td class="hover-bg ts-meta" data-tsmeta="grap"><span>Grappling</span></td>
                     <td class="dark-bg hover-bg ts-meta" data-tsmeta="grap"><span>Grappling War Room</span></td>
-
-                    <td class="blank-td"><span></span></td>
-                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="grap"><span>Grappling</span></td>
-                    <td class="blank-td"><span></span></td>
-                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="grap"><span>Grappling</span></td>
-                    <td class="hover-bg ts-meta" data-tsmeta="grap"><span>Grappling War Room</span></td>
-
                   </tr>
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">19:00h - 20:00h</span></td>

--- a/jjbPage.html
+++ b/jjbPage.html
@@ -661,14 +661,6 @@ Aquí, cada clase es un paso hacia la superación personal, en un ambiente segur
                     <td class="blank-td"><span></span></td>
                     <td class="dark-bg blank-td"><span></span></td>
                   </tr>
-                  <tr>
-                    <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">20:00h - 21:00h</span></td>
-                    <td class="hover-bg ts-meta" data-tsmeta="bjj"><span>BJJ</span></td>
-                    <td class="dark-bg blank-td"><span></span></td>
-                    <td class="hover-bg ts-meta" data-tsmeta="bjj"><span>BJJ</span></td>
-                    <td class="dark-bg blank-td"><span></span></td>
-                    <td class="blank-td"><span></span></td>
-                  </tr>
                 </tbody>
               </table>
             </div>

--- a/mmaPage.html
+++ b/mmaPage.html
@@ -600,19 +600,12 @@
                   </tr>
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">18:00h - 19:00h</span></td>
- 
+
                     <td class="blank-td ts-meta" data-tsmeta="mma"><span></span></td>
                     <td class="dark-bg blank-td ts-meta" data-tsmeta="mma"><span></span></td>
                     <td class="blank-td ts-meta" data-tsmeta="mma"><span></span></td>
                     <td class="dark-bg blank-td ts-meta" data-tsmeta="mma"><span></span></td>
                     <td class="hover-bg ts-meta" data-tsmeta="mma"><span>MMA Sparring</span></td>
-
-                    <td class="dark-bg blank-td ts-meta" data-tsmeta="mma"><span></span></td>
-                    <td class="blank-td ts-meta" data-tsmeta="mma"><span></span></td>
-                    <td class="dark-bg blank-td ts-meta" data-tsmeta="mma"><span></span></td>
-                    <td class="blank-td ts-meta" data-tsmeta="mma"><span></span></td>
-                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="mma"><span>MMA Sparring</span></td>
- 
                   </tr>
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">20:00h - 21:00h</span></td>
@@ -624,20 +617,12 @@
                   </tr>
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">21:00h - 22:00h</span></td>
- 
+
                     <td class="hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
                     <td class="dark-bg blank-td ts-meta" data-tsmeta="mma"><span></span></td>
                     <td class="hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
                     <td class="dark-bg blank-td ts-meta" data-tsmeta="mma"><span></span></td>
                     <td class="blank-td ts-meta" data-tsmeta="mma"><span></span></td>
-
-                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
-                    <td class="blank-td ts-meta" data-tsmeta="mma"><span></span></td>
-                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
-                    <td class="blank-td ts-meta" data-tsmeta="mma"><span></span></td>
-                    <td class="dark-bg blank-td ts-meta" data-tsmeta="mma"><span></span></td>
-
-     
                   </tr>
                 </tbody>
               </table>


### PR DESCRIPTION
## Summary
- remove weekend columns from main class timetable
- clean up MMA, BJJ and Grappling page schedules to stop at Friday

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d7b38718832b9009a29274d3a76c