### PR TITLE
Add simple login and registration pages

### DIFF
--- a/css/auth.css
+++ b/css/auth.css
@@ -1,0 +1,32 @@
+body {
+  background: #f4f4f4;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  font-family: 'Muli', sans-serif;
+}
+
+.auth-container {
+  background: #fff;
+  padding: 30px;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0,0,0,0.1);
+  width: 100%;
+  max-width: 400px;
+}
+
+.auth-container h2 {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.auth-container .switch-link {
+  text-align: center;
+  margin-top: 15px;
+}
+
+.auth-message {
+  text-align: center;
+  margin-top: 10px;
+}

--- a/index.html
+++ b/index.html
@@ -123,6 +123,7 @@
           <li><a href="./class-timetable.html">Horario</a></li>
           <li><a href="./gallery.html">Galería</a></li>
           <li><a href="./store.html">Tienda</a></li>
+          <li><a href="./login.html">Acceso</a></li>
           <li><a href="./contact.html">Contacto</a></li>
         </ul>
       </nav>
@@ -208,6 +209,7 @@
                 <li><a href="./class-timetable.html">Horario</a></li>
                 <li><a href="./gallery.html">Galería</a></li>
                 <li><a href="./store.html">Tienda</a></li>
+                <li><a href="./login.html">Acceso</a></li>
                 <li><a href="./contact.html">Contacto</a></li>
               </ul>
             </nav>

--- a/js/auth.js
+++ b/js/auth.js
@@ -1,0 +1,50 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const loginForm = document.getElementById('loginForm');
+  const registerForm = document.getElementById('registerForm');
+
+  if (loginForm) {
+    loginForm.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const user = document.getElementById('loginUser').value.trim();
+      const pass = document.getElementById('loginPass').value;
+      const users = JSON.parse(localStorage.getItem('users') || '{}');
+      const message = document.getElementById('loginMessage');
+      if (users[user] && users[user] === pass) {
+        message.textContent = 'Inicio de sesión exitoso';
+        message.style.color = 'green';
+        localStorage.setItem('currentUser', user);
+        loginForm.reset();
+      } else {
+        message.textContent = 'Usuario o contraseña incorrectos';
+        message.style.color = 'red';
+      }
+    });
+  }
+
+  if (registerForm) {
+    registerForm.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const user = document.getElementById('regUser').value.trim();
+      const pass = document.getElementById('regPass').value;
+      const pass2 = document.getElementById('regPass2').value;
+      const message = document.getElementById('registerMessage');
+      const users = JSON.parse(localStorage.getItem('users') || '{}');
+
+      if (pass !== pass2) {
+        message.textContent = 'Las contraseñas no coinciden';
+        message.style.color = 'red';
+        return;
+      }
+      if (users[user]) {
+        message.textContent = 'El usuario ya existe';
+        message.style.color = 'red';
+        return;
+      }
+      users[user] = pass;
+      localStorage.setItem('users', JSON.stringify(users));
+      message.textContent = 'Registro exitoso, ya puedes iniciar sesión';
+      message.style.color = 'green';
+      registerForm.reset();
+    });
+  }
+});

--- a/login.html
+++ b/login.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link href="https://fonts.googleapis.com/css?family=Muli:300,400,500,600,700,800,900&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/bootstrap.min.css" />
+  <link rel="stylesheet" href="css/auth.css" />
+  <title>Login - Sparta MMA</title>
+</head>
+<body>
+  <div class="auth-container">
+    <h2>Iniciar Sesión</h2>
+    <form id="loginForm">
+      <div class="form-group">
+        <label for="loginUser">Usuario</label>
+        <input type="text" class="form-control" id="loginUser" required />
+      </div>
+      <div class="form-group">
+        <label for="loginPass">Contraseña</label>
+        <input type="password" class="form-control" id="loginPass" required />
+      </div>
+      <button type="submit" class="btn btn-primary btn-block">Entrar</button>
+      <p class="auth-message" id="loginMessage"></p>
+      <p class="switch-link">¿No tienes cuenta? <a href="register.html">Regístrate</a></p>
+    </form>
+  </div>
+  <script src="js/auth.js"></script>
+</body>
+</html>

--- a/register.html
+++ b/register.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link href="https://fonts.googleapis.com/css?family=Muli:300,400,500,600,700,800,900&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/bootstrap.min.css" />
+  <link rel="stylesheet" href="css/auth.css" />
+  <title>Registro - Sparta MMA</title>
+</head>
+<body>
+  <div class="auth-container">
+    <h2>Registro</h2>
+    <form id="registerForm">
+      <div class="form-group">
+        <label for="regUser">Usuario</label>
+        <input type="text" class="form-control" id="regUser" required />
+      </div>
+      <div class="form-group">
+        <label for="regPass">Contraseña</label>
+        <input type="password" class="form-control" id="regPass" required />
+      </div>
+      <div class="form-group">
+        <label for="regPass2">Confirmar Contraseña</label>
+        <input type="password" class="form-control" id="regPass2" required />
+      </div>
+      <button type="submit" class="btn btn-primary btn-block">Registrar</button>
+      <p class="auth-message" id="registerMessage"></p>
+      <p class="switch-link">¿Ya tienes cuenta? <a href="login.html">Inicia sesión</a></p>
+    </form>
+  </div>
+  <script src="js/auth.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add login and registration pages styled with Bootstrap
- store users in localStorage and show basic messages
- link to login page from main navigation

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cd8930e4832b96c168cb81e8ea28