### PR TITLE
Fix navbar alignment and offcanvas menu display

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -487,8 +487,8 @@ ol {
 
 .nav-menu {
   text-align: center;
-  min-width: 80vw;
-  margin-left: -15vw;
+  width: 100%;
+  margin-left: 0;
 }
 
 .nav-menu ul li {

--- a/js/main.js
+++ b/js/main.js
@@ -29,12 +29,12 @@
 
     //Canvas Menu
     $(".canvas-open").on('click', function () {
-        $(".offcanvas-menu-wrapper").addClass("show-offcanvas-menu-wrapper");
+        $(".offcanvas-menu-wrapper").css("display", "block").addClass("show-offcanvas-menu-wrapper");
         $(".offcanvas-menu-overlay").addClass("active");
     });
 
     $(".canvas-close, .offcanvas-menu-overlay").on('click', function () {
-        $(".offcanvas-menu-wrapper").removeClass("show-offcanvas-menu-wrapper");
+        $(".offcanvas-menu-wrapper").removeClass("show-offcanvas-menu-wrapper").css("display", "none");
         $(".offcanvas-menu-overlay").removeClass("active");
     });
 


### PR DESCRIPTION
## Summary
- ensure nav menu stays within viewport by removing fixed width and negative margin
- display offcanvas menu when opened so blur overlay shows navigation options

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3bbba3d94832b994c04c157d30bf7