### PR TITLE
Ajusta patrón de celdas en horario

### DIFF
--- a/class-timetable.html
+++ b/class-timetable.html
@@ -288,19 +288,19 @@ td{padding-top:5px !important;padding-bottom:5px !important;}}
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">11:00h - 12:00h</span></td>
 
-                    <td class="hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
                     <td class="dark-bg hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
                     <td class="hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
                     <td class="dark-bg hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
-                    <td class="hover-bg ts-meta" data-tsmeta="mma"><span>MMA Sparring</span></td>
+                    <td class="hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
+                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="mma"><span>MMA Sparring</span></td>
                   </tr>
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">12:00h - 13:00h</span></td>
-                    <td class="hover-bg ts-meta" data-tsmeta="grap"><span>Grappling Shark Tank</span></td>
-                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="bjj"><span>BJJ</span></td>
-                    <td class="hover-bg ts-meta" data-tsmeta="grap"><span>Grappling Shark Tank</span></td>
-                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="bjj"><span>BJJ</span></td>
-                    <td class="blank-td"><span></span></td>
+                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="grap"><span>Grappling Shark Tank</span></td>
+                    <td class="hover-bg ts-meta" data-tsmeta="bjj"><span>BJJ</span></td>
+                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="grap"><span>Grappling Shark Tank</span></td>
+                    <td class="hover-bg ts-meta" data-tsmeta="bjj"><span>BJJ</span></td>
+                    <td class="dark-bg blank-td"><span></span></td>
                   </tr>
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">17:00h - 18:00h</span></td>
@@ -308,16 +308,16 @@ td{padding-top:5px !important;padding-bottom:5px !important;}}
                     <td class="hover-bg ts-meta" data-tsmeta="kids"><span>Spartan Kids</span></td>
                     <td class="dark-bg hover-bg ts-meta" data-tsmeta="kids"><span>BJJ Kids</span></td>
                     <td class="hover-bg ts-meta" data-tsmeta="kids"><span>Spartan Kids</span></td>
-                    <td class="dark-bg blank-td ts-meta" data-tsmeta="kids"><span></span></td>
+                    <td class="dark-bg blank-td"><span></span></td>
                   </tr>
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">18:00h - 19:00h</span></td>
 
-                    <td class="blank-td ts-meta" data-tsmeta="mma"><span></span></td>
-                    <td class="dark-bg blank-td ts-meta" data-tsmeta="mma"><span></span></td>
-                    <td class="blank-td ts-meta" data-tsmeta="mma"><span></span></td>
-                    <td class="dark-bg blank-td ts-meta" data-tsmeta="mma"><span></span></td>
-                    <td class="hover-bg ts-meta" data-tsmeta="mma"><span>MMA Sparring</span></td>
+                    <td class="dark-bg blank-td"><span></span></td>
+                    <td class="blank-td"><span></span></td>
+                    <td class="dark-bg blank-td"><span></span></td>
+                    <td class="blank-td"><span></span></td>
+                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="mma"><span>MMA Sparring</span></td>
                   </tr>
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">19:00h - 20:00h</span></td>
@@ -330,11 +330,11 @@ td{padding-top:5px !important;padding-bottom:5px !important;}}
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">20:00h - 21:00h</span></td>
 
-                    <td class="hover-bg ts-meta" data-tsmeta="bjj"><span>BJJ</span></td>
-                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
-                    <td class="hover-bg ts-meta" data-tsmeta="bjj"><span>BJJ</span></td>
-                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
-                    <td class="blank-td ts-meta" data-tsmeta="mma"><span></span></td>
+                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="bjj"><span>BJJ</span></td>
+                    <td class="hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
+                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="bjj"><span>BJJ</span></td>
+                    <td class="hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
+                    <td class="dark-bg blank-td"><span></span></td>
                   </tr>
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">21:00h - 22:00h</span></td>
@@ -342,7 +342,7 @@ td{padding-top:5px !important;padding-bottom:5px !important;}}
                     <td class="hover-bg ts-meta" data-tsmeta="bjj"><span>BJJ</span></td>
                     <td class="dark-bg hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
                     <td class="hover-bg ts-meta" data-tsmeta="bjj"><span>BJJ</span></td>
-                    <td class="dark-bg blank-td ts-meta" data-tsmeta="mma"><span></span></td>
+                    <td class="dark-bg blank-td"><span></span></td>
                   </tr>
                 </tbody>
               </table>
@@ -387,10 +387,10 @@ td{padding-top:5px !important;padding-bottom:5px !important;}}
                   </tr>
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">11:00h - 12:00h</span></td>
-                    <td class="blank-td"><span></span></td>
-                    <td class="dark-bg hover-bg"><span>MMA Iniciación</span></td>
-                    <td class="blank-td"><span></span></td>
-                    <td class="dark-bg hover-bg"><span>MMA Iniciación</span></td>
+                    <td class="dark-bg blank-td"><span></span></td>
+                    <td class="hover-bg"><span>MMA Iniciación</span></td>
+                    <td class="dark-bg blank-td"><span></span></td>
+                    <td class="hover-bg"><span>MMA Iniciación</span></td>
                   </tr>
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">20:00h - 21:00h</span></td>
@@ -401,10 +401,10 @@ td{padding-top:5px !important;padding-bottom:5px !important;}}
                   </tr>
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">21:15h - 22:15h</span></td>
-                    <td class="blank-td"><span></span></td>
-                    <td class="dark-bg hover-bg"><span>MMA Iniciación</span></td>
-                    <td class="blank-td"><span></span></td>
-                    <td class="dark-bg hover-bg"><span>MMA Iniciación</span></td>
+                    <td class="dark-bg blank-td"><span></span></td>
+                    <td class="hover-bg"><span>MMA Iniciación</span></td>
+                    <td class="dark-bg blank-td"><span></span></td>
+                    <td class="hover-bg"><span>MMA Iniciación</span></td>
                   </tr>
                 </tbody>
               </table>


### PR DESCRIPTION
## Summary
- aplica un patrón ajedrezado de `dark-bg` en las columnas de lunes a viernes del horario
- marca todas las celdas con contenido como `hover-bg` y deja las vacías con `blank-td`

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc199f8488832bb7366d8d4c2df324