### PR TITLE
Alterna los colores del horario por fila

### DIFF
--- a/class-timetable.html
+++ b/class-timetable.html
@@ -288,11 +288,11 @@ td{padding-top:5px !important;padding-bottom:5px !important;}}
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">11:00h - 12:00h</span></td>
 
-                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
                     <td class="hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
                     <td class="dark-bg hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
                     <td class="hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
-                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="mma"><span>MMA Sparring</span></td>
+                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
+                    <td class="hover-bg ts-meta" data-tsmeta="mma"><span>MMA Sparring</span></td>
                   </tr>
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">12:00h - 13:00h</span></td>
@@ -304,11 +304,11 @@ td{padding-top:5px !important;padding-bottom:5px !important;}}
                   </tr>
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">17:00h - 18:00h</span></td>
-                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="kids"><span>BJJ Kids</span></td>
-                    <td class="hover-bg ts-meta" data-tsmeta="kids"><span>Spartan Kids</span></td>
-                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="kids"><span>BJJ Kids</span></td>
-                    <td class="hover-bg ts-meta" data-tsmeta="kids"><span>Spartan Kids</span></td>
-                    <td class="dark-bg blank-td"><span></span></td>
+                    <td class="hover-bg ts-meta" data-tsmeta="kids"><span>BJJ Kids</span></td>
+                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="kids"><span>Spartan Kids</span></td>
+                    <td class="hover-bg ts-meta" data-tsmeta="kids"><span>BJJ Kids</span></td>
+                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="kids"><span>Spartan Kids</span></td>
+                    <td class="blank-td"><span></span></td>
                   </tr>
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">18:00h - 19:00h</span></td>
@@ -321,11 +321,11 @@ td{padding-top:5px !important;padding-bottom:5px !important;}}
                   </tr>
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">19:00h - 20:00h</span></td>
-                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="grap"><span>Grappling Shark Tank</span></td>
                     <td class="hover-bg ts-meta" data-tsmeta="grap"><span>Grappling Shark Tank</span></td>
                     <td class="dark-bg hover-bg ts-meta" data-tsmeta="grap"><span>Grappling Shark Tank</span></td>
                     <td class="hover-bg ts-meta" data-tsmeta="grap"><span>Grappling Shark Tank</span></td>
-                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="grap"><span>Grappling War Room</span></td>
+                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="grap"><span>Grappling Shark Tank</span></td>
+                    <td class="hover-bg ts-meta" data-tsmeta="grap"><span>Grappling War Room</span></td>
                   </tr>
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">20:00h - 21:00h</span></td>
@@ -338,11 +338,11 @@ td{padding-top:5px !important;padding-bottom:5px !important;}}
                   </tr>
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">21:00h - 22:00h</span></td>
-                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
-                    <td class="hover-bg ts-meta" data-tsmeta="bjj"><span>BJJ</span></td>
-                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
-                    <td class="hover-bg ts-meta" data-tsmeta="bjj"><span>BJJ</span></td>
-                    <td class="dark-bg blank-td"><span></span></td>
+                    <td class="hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
+                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="bjj"><span>BJJ</span></td>
+                    <td class="hover-bg ts-meta" data-tsmeta="mma"><span>MMA</span></td>
+                    <td class="dark-bg hover-bg ts-meta" data-tsmeta="bjj"><span>BJJ</span></td>
+                    <td class="blank-td"><span></span></td>
                   </tr>
                 </tbody>
               </table>
@@ -387,10 +387,10 @@ td{padding-top:5px !important;padding-bottom:5px !important;}}
                   </tr>
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">11:00h - 12:00h</span></td>
-                    <td class="dark-bg blank-td"><span></span></td>
-                    <td class="hover-bg"><span>MMA Iniciación</span></td>
-                    <td class="dark-bg blank-td"><span></span></td>
-                    <td class="hover-bg"><span>MMA Iniciación</span></td>
+                    <td class="blank-td"><span></span></td>
+                    <td class="dark-bg hover-bg"><span>MMA Iniciación</span></td>
+                    <td class="blank-td"><span></span></td>
+                    <td class="dark-bg hover-bg"><span>MMA Iniciación</span></td>
                   </tr>
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">20:00h - 21:00h</span></td>
@@ -401,10 +401,10 @@ td{padding-top:5px !important;padding-bottom:5px !important;}}
                   </tr>
                   <tr>
                     <td class="dark-bg" style="background-color: black;"><span style="font-weight: bolder; color: white;">21:15h - 22:15h</span></td>
-                    <td class="dark-bg blank-td"><span></span></td>
-                    <td class="hover-bg"><span>MMA Iniciación</span></td>
-                    <td class="dark-bg blank-td"><span></span></td>
-                    <td class="hover-bg"><span>MMA Iniciación</span></td>
+                    <td class="blank-td"><span></span></td>
+                    <td class="dark-bg hover-bg"><span>MMA Iniciación</span></td>
+                    <td class="blank-td"><span></span></td>
+                    <td class="dark-bg hover-bg"><span>MMA Iniciación</span></td>
                   </tr>
                 </tbody>
               </table>


### PR DESCRIPTION
## Summary
- alternated dark/light timetable column backgrounds by row to achieve a checkerboard effect across weekdays
- ensured blank cells and the alternate location schedule follow the same alternating pattern for consistency

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc1f2950e4832b8857af019e210e27