### PR TITLE
Add schedule download buttons to timetable page

### DIFF
--- a/class-timetable.html
+++ b/class-timetable.html
@@ -357,6 +357,14 @@ td{padding-top:5px !important;padding-bottom:5px !important;}}
                   </tr>
                 </tbody>
               </table>
+              <div class="text-center mt-3">
+                <a
+                  href="#"
+                  class="primary-btn btn-normal"
+                  onclick="downloadSchedule('toledo_table', 'horario-sede-central.png'); return false;"
+                  >Descargar horario</a
+                >
+              </div>
               <!--  <td
                       class="hover-bg ts-meta"
                       style="background-color: #383838"
@@ -419,6 +427,14 @@ td{padding-top:5px !important;padding-bottom:5px !important;}}
                   </tr>
                 </tbody>
               </table>
+              <div class="text-center mt-3">
+                <a
+                  href="#"
+                  class="primary-btn btn-normal"
+                  onclick="downloadSchedule('limite_table', 'horario-gimnasio-limite.png'); return false;"
+                  >Descargar horario</a
+                >
+              </div>
             </div>
           </div>
         </div>
@@ -643,6 +659,7 @@ td{padding-top:5px !important;padding-bottom:5px !important;}}
     <script src="js/jquery.barfiller.js"></script>
     <script src="js/jquery.slicknav.js"></script>
     <script src="js/owl.carousel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
     <script src="js/main.js"></script>
   </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -276,5 +276,37 @@ function toledoHorario(){
 }
 
 
+function downloadSchedule(wrapperId, filename) {
+    var wrapper = document.getElementById(wrapperId);
+    if (!wrapper) {
+        console.warn('No se encontró el contenedor del horario con id:', wrapperId);
+        return;
+    }
+
+    var table = wrapper.querySelector('table');
+    if (!table) {
+        console.warn('No se encontró la tabla dentro del contenedor:', wrapperId);
+        return;
+    }
+
+    var scale = Math.max(window.devicePixelRatio || 1, 2);
+
+    html2canvas(table, {
+        backgroundColor: '#000',
+        scale: scale,
+        useCORS: true
+    }).then(function (canvas) {
+        var link = document.createElement('a');
+        link.href = canvas.toDataURL('image/png');
+        link.download = filename || 'horario.png';
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+    }).catch(function (error) {
+        console.error('No se pudo generar la imagen del horario:', error);
+    });
+}
+
+
 
 


### PR DESCRIPTION
## Summary
- load html2canvas on the timetable page to support rendering tables as images
- add download controls for each location and implement a shared download helper

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dc2b2e271c832b82b7645e92201298