### PR TITLE
Add schedule downloads to discipline pages and lazy-load images

### DIFF
--- a/grapPage.html
+++ b/grapPage.html
@@ -507,7 +507,7 @@ hacerlo con un método y en un ambiente personalizados.
         </div>
         <div class="row">
           <div class="col-lg-12">
-            <div class="class-timetable">
+            <div class="class-timetable" id="grappling_schedule_table">
               <table>
                 <thead>
                   <tr>
@@ -548,6 +548,14 @@ hacerlo con un método y en un ambiente personalizados.
                   </tr>
                 </tbody>
               </table>
+              <div class="text-center mt-3">
+                <a
+                  href="#"
+                  class="primary-btn btn-normal"
+                  onclick="downloadSchedule('grappling_schedule_table', 'horario-grappling.png'); return false;"
+                  >Descargar horario</a
+                >
+              </div>
             </div>
           </div>
         </div>
@@ -798,6 +806,7 @@ hacerlo con un método y en un ambiente personalizados.
     <script src="js/jquery.barfiller.js"></script>
     <script src="js/jquery.slicknav.js"></script>
     <script src="js/owl.carousel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
     <script src="js/main.js"></script>
   </body>
 </html>

--- a/jjbPage.html
+++ b/jjbPage.html
@@ -629,7 +629,7 @@ Aquí, cada clase es un paso hacia la superación personal, en un ambiente segur
         </div>
         <div class="row">
           <div class="col-lg-12">
-            <div class="class-timetable">
+            <div class="class-timetable" id="bjj_schedule_table">
               <table>
                 <thead>
                   <tr>
@@ -679,6 +679,14 @@ Aquí, cada clase es un paso hacia la superación personal, en un ambiente segur
                   </tr>
                 </tbody>
               </table>
+              <div class="text-center mt-3">
+                <a
+                  href="#"
+                  class="primary-btn btn-normal"
+                  onclick="downloadSchedule('bjj_schedule_table', 'horario-bjj.png'); return false;"
+                  >Descargar horario</a
+                >
+              </div>
             </div>
           </div>
         </div>
@@ -928,6 +936,7 @@ Aquí, cada clase es un paso hacia la superación personal, en un ambiente segur
     <script src="js/jquery.barfiller.js"></script>
     <script src="js/jquery.slicknav.js"></script>
     <script src="js/owl.carousel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
     <script src="js/main.js"></script>
   </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -22,9 +22,40 @@
     /*------------------
         Background Set
     --------------------*/
-    $('.set-bg').each(function () {
-        var bg = $(this).data('setbg');
-        $(this).css('background-image', 'url(' + bg + ')');
+    function setBackgroundImage(element) {
+        var $el = $(element);
+        var bg = $el.data('setbg');
+
+        if (!bg) {
+            return;
+        }
+
+        $el.css('background-image', 'url(' + bg + ')');
+        $el.addClass('bg-loaded');
+    }
+
+    if ('IntersectionObserver' in window) {
+        var lazyBgObserver = new IntersectionObserver(function (entries, observer) {
+            entries.forEach(function (entry) {
+                if (entry.isIntersecting) {
+                    setBackgroundImage(entry.target);
+                    observer.unobserve(entry.target);
+                }
+            });
+        }, { rootMargin: '200px 0px' });
+
+        $('.set-bg').each(function () {
+            lazyBgObserver.observe(this);
+        });
+    } else {
+        $('.set-bg').each(function () {
+            setBackgroundImage(this);
+        });
+    }
+
+    $('img[load="lazy"]').each(function () {
+        $(this).attr('loading', 'lazy');
+        $(this).removeAttr('load');
     });
 
     //Canvas Menu

--- a/kidsPage.html
+++ b/kidsPage.html
@@ -227,7 +227,7 @@
         </div>
         <div class="row">
           <div class="col-lg-12">
-            <div class="class-timetable">
+            <div class="class-timetable" id="kids_schedule_table">
               <table>
                 <thead>
                   <tr>
@@ -251,6 +251,14 @@
                   </tr>
                 </tbody>
               </table>
+              <div class="text-center mt-3">
+                <a
+                  href="#"
+                  class="primary-btn btn-normal"
+                  onclick="downloadSchedule('kids_schedule_table', 'horario-spartan-kids.png'); return false;"
+                  >Descargar horario</a
+                >
+              </div>
             </div>
           </div>
         </div>
@@ -504,6 +512,7 @@
     <script src="js/jquery.barfiller.js"></script>
     <script src="js/jquery.slicknav.js"></script>
     <script src="js/owl.carousel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
     <script src="js/main.js"></script>
   </body>
 </html>

--- a/mmaPage.html
+++ b/mmaPage.html
@@ -577,7 +577,7 @@
         </div>
         <div class="row">
           <div class="col-lg-12">
-            <div class="class-timetable">
+            <div class="class-timetable" id="mma_schedule_table">
               <table>
                 <thead>
                   <tr>
@@ -627,6 +627,14 @@
                   </tr>
                 </tbody>
               </table>
+              <div class="text-center mt-3">
+                <a
+                  href="#"
+                  class="primary-btn btn-normal"
+                  onclick="downloadSchedule('mma_schedule_table', 'horario-mma.png'); return false;"
+                  >Descargar horario</a
+                >
+              </div>
             </div>
           </div>
         </div>
@@ -873,6 +881,7 @@
     <script src="js/jquery.barfiller.js"></script>
     <script src="js/jquery.slicknav.js"></script>
     <script src="js/owl.carousel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
     <script src="js/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add schedule download buttons to the MMA, BJJ, Grappling and Spartan Kids discipline pages
- include html2canvas on each discipline page so the download action works consistently
- lazy-load background images and normal <img> tags marked for lazy loading to improve gallery performance

## Testing
- not run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68dc406483f4832bb85e529b554bd8c1