### PR TITLE
Update pricing and checkout links for Sparta MMA

### DIFF
--- a/prices.html
+++ b/prices.html
@@ -248,41 +248,41 @@
             <div class="ps-item">
               <h3>1 Disciplina</h3>
               <div class="pi-price">
-                <h2>€ 50.0</h2>
+                <h2>€ 60</h2>
                 <span>/ mes</span>
               </div>
               <ul>
                 <li>MMA, BJJ o Grappling</li>
                 <li>¡Elige con cuál quieres empezar!</li>
               </ul>
-              <a href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02LgFE7HmWSisrIa0MFgoR" class="primary-btn pricing-btn">Apúntate ya</a>
+              <a href="https://checkout.joinmaat.com?gymId=sparta_mma&priceId=price_1TGiD5FE7HmWSisrEJ1nnWjd" class="primary-btn pricing-btn">Apúntate ya</a>
             </div>
           </div>
           <div class="col-lg-4 col-md-8">
             <div class="ps-item">
               <h3>2 Disciplinas</h3>
               <div class="pi-price">
-                <h2>€ 80.0</h2>
+                <h2>€ 90</h2>
                 <span>/ mes</span>
               </div>
               <ul>
                 <li>MMA, BJJ o Grappling</li>
                 <li>¡Combina las dos disciplinas que más te gusten!</li>
               </ul>
-              <a href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02MMFE7HmWSisrfTmCt4Nc" class="primary-btn pricing-btn">Apúntate ya</a>
+              <a href="https://checkout.joinmaat.com?gymId=sparta_mma&priceId=price_1TGiEtFE7HmWSisrksJWhIYh" class="primary-btn pricing-btn">Apúntate ya</a>
             </div>
           </div>
           <div class="col-lg-4 col-md-8">
             <div class="ps-item">
               <h3>3 Disciplinas</h3>
               <div class="pi-price">
-                <h2>€ 100.0</h2>
+                <h2>€ 110</h2>
                 <span>/ mes</span>
               </div>
               <ul>
                 <li>Entrena todas las disciplinas</li>
               </ul>
-              <a href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02MaFE7HmWSisr3GlGmY3I" class="primary-btn pricing-btn">Apúntate ya</a>
+              <a href="https://checkout.joinmaat.com?gymId=sparta_mma&priceId=price_1TGiFsFE7HmWSisr3NEAuoG2" class="primary-btn pricing-btn">Apúntate ya</a>
             </div>
           </div>
           <div class="col-lg-4 col-md-8">
@@ -290,16 +290,29 @@
               <h3>BJJ Spartan Kids</h3>
               <h3>Infantiles (2 días / semana)</h3>
               <div class="pi-price">
-                <h2>€ 50.0</h2>
+                <h2>€ 60</h2>
                 <span>/ mes</span>
               </div>
               <ul>
                 <li>2 días por semana</li>
               </ul>
-              <a href="https://checkout.joinmaat.com/?gymId=sparta_mma&priceId=price_1S02N4FE7HmWSisr9px4l123" class="primary-btn pricing-btn">Apúntate ya</a>
+              <a href="https://checkout.joinmaat.com?gymId=sparta_mma&priceId=price_1TGiGxFE7HmWSisrwDCk96Ti" class="primary-btn pricing-btn">Apúntate ya</a>
             </div>
           </div>
-        
+          <div class="col-lg-4 col-md-8">
+            <div class="ps-item">
+              <h3>MMA Juvenil</h3>
+              <div class="pi-price">
+                <h2>€ 60</h2>
+                <span>/ mes</span>
+              </div>
+              <ul>
+                <li>Programa juvenil de MMA</li>
+              </ul>
+              <a href="https://checkout.joinmaat.com?gymId=sparta_mma&priceId=price_1TGiHOFE7HmWSisr8Iv8FfOf" class="primary-btn pricing-btn">Apúntate ya</a>
+            </div>
+          </div>
+
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
Updated the pricing page with new pricing tiers and checkout links for all membership options, plus added a new juvenile MMA program offering.

## Key Changes
- **Price increases across all tiers:**
  - 1 Disciplina: €50 → €60/month
  - 2 Disciplinas: €80 → €90/month
  - 3 Disciplinas: €100 → €110/month
  - BJJ Spartan Kids: €50 → €60/month

- **Updated checkout links:** All Maat checkout URLs have been updated with new price IDs to reflect the pricing changes:
  - Removed query parameter syntax (`/?`) in favor of standard format (`?`)
  - Updated all `priceId` parameters with new IDs

- **New offering:** Added "MMA Juvenil" (Juvenile MMA) program at €60/month with dedicated checkout link

## Implementation Details
- All pricing updates maintain the same membership structure and descriptions
- Checkout links follow consistent URL formatting across all tiers
- New juvenile MMA program integrates seamlessly with existing pricing grid layout

https://claude.ai/code/session_01MU4zon8i2MKtzZbhDjBjbU